### PR TITLE
feat: convert Zod schemas to JSON Schema

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,9 @@ export {
   SchemaValidationError,
 } from "./errors.ts"
 
+export { jsonSchemaFromZod } from "./schema.ts"
+export type { JsonSchema } from "./schema.ts"
+
 /**
  * Wrap an LLM client with schema-validated create().
  * The original client is not mutated.

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,0 +1,140 @@
+import { z, type ZodTypeAny } from "zod"
+
+/** JSON Schema subset emitted for LLM tool / json_schema payloads. */
+export type JsonSchema = {
+  type?: string | string[]
+  properties?: Record<string, JsonSchema>
+  required?: string[]
+  additionalProperties?: boolean
+  enum?: Array<string | number | null>
+  description?: string
+  anyOf?: JsonSchema[]
+}
+
+type ZodDef = {
+  typeName: string
+  innerType?: ZodTypeAny
+  schema?: ZodTypeAny
+  type?: ZodTypeAny
+  description?: string
+  values?: string[]
+  checks?: Array<{ kind: string }>
+}
+
+function def(schema: ZodTypeAny): ZodDef {
+  return schema._def as ZodDef
+}
+
+/**
+ * Convert a Zod schema into JSON Schema.
+ *
+ * v0 supports objects (including nested), string, number, int, boolean,
+ * enum, optional, and nullable. Other Zod types throw.
+ */
+export function jsonSchemaFromZod(schema: ZodTypeAny): JsonSchema {
+  const { inner, optional, nullable } = unwrap(schema)
+  const json = convert(inner)
+
+  const description = def(schema).description ?? def(inner).description
+  if (description !== undefined) {
+    json.description = description
+  }
+
+  if (nullable) {
+    return { anyOf: [json, { type: "null" }] }
+  }
+
+  // `optional` is used by object fields (omitted from `required`).
+  void optional
+  return json
+}
+
+function unwrap(schema: ZodTypeAny): {
+  inner: ZodTypeAny
+  optional: boolean
+  nullable: boolean
+} {
+  let inner = schema
+  let optional = false
+  let nullable = false
+
+  for (;;) {
+    const typeName = def(inner).typeName
+    if (typeName === "ZodOptional") {
+      optional = true
+      inner = def(inner).innerType as ZodTypeAny
+      continue
+    }
+    if (typeName === "ZodNullable") {
+      nullable = true
+      inner = def(inner).innerType as ZodTypeAny
+      continue
+    }
+    if (typeName === "ZodDefault") {
+      inner = def(inner).innerType as ZodTypeAny
+      continue
+    }
+    if (typeName === "ZodEffects") {
+      inner = def(inner).schema as ZodTypeAny
+      continue
+    }
+    if (typeName === "ZodBranded") {
+      inner = def(inner).type as ZodTypeAny
+      continue
+    }
+    break
+  }
+
+  return { inner, optional, nullable }
+}
+
+function convert(schema: ZodTypeAny): JsonSchema {
+  const typeName = def(schema).typeName
+
+  switch (typeName) {
+    case "ZodString":
+      return { type: "string" }
+    case "ZodNumber": {
+      const isInt = (def(schema).checks ?? []).some((check) => check.kind === "int")
+      return { type: isInt ? "integer" : "number" }
+    }
+    case "ZodBoolean":
+      return { type: "boolean" }
+    case "ZodEnum":
+      return { type: "string", enum: [...(def(schema).values ?? [])] }
+    case "ZodObject":
+      return convertObject(schema as z.ZodObject<z.ZodRawShape>)
+    default:
+      throw new Error(
+        `Unsupported Zod type "${typeName}". v0 supports object, string, number, int, boolean, enum, optional, and nullable.`,
+      )
+  }
+}
+
+function convertObject(schema: z.ZodObject<z.ZodRawShape>): JsonSchema {
+  const properties: Record<string, JsonSchema> = {}
+  const required: string[] = []
+
+  for (const [key, field] of Object.entries(schema.shape)) {
+    const { inner, optional, nullable } = unwrap(field)
+    const json = convert(inner)
+    const description = def(field).description ?? def(inner).description
+    if (description !== undefined) {
+      json.description = description
+    }
+    properties[key] = nullable ? { anyOf: [json, { type: "null" }] } : json
+    if (!optional) {
+      required.push(key)
+    }
+  }
+
+  const result: JsonSchema = {
+    type: "object",
+    properties,
+    additionalProperties: false,
+  }
+  if (required.length > 0) {
+    result.required = required
+  }
+  return result
+}

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+import { jsonSchemaFromZod } from "../src/schema.ts"
+
+describe("jsonSchemaFromZod", () => {
+  it("converts a flat object with string and int", () => {
+    const User = z.object({
+      name: z.string(),
+      age: z.number().int(),
+    })
+
+    expect(jsonSchemaFromZod(User)).toEqual({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        name: { type: "string" },
+        age: { type: "integer" },
+      },
+      required: ["name", "age"],
+    })
+  })
+
+  it("converts nested objects", () => {
+    const Profile = z.object({
+      user: z.object({
+        name: z.string(),
+      }),
+    })
+
+    expect(jsonSchemaFromZod(Profile)).toEqual({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        user: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            name: { type: "string" },
+          },
+          required: ["name"],
+        },
+      },
+      required: ["user"],
+    })
+  })
+
+  it("omits optional fields from required", () => {
+    const Model = z.object({
+      name: z.string(),
+      nickname: z.string().optional(),
+    })
+
+    const schema = jsonSchemaFromZod(Model)
+    expect(schema.required).toEqual(["name"])
+    expect(schema.properties?.["nickname"]).toEqual({ type: "string" })
+  })
+
+  it("encodes nullable fields as anyOf null", () => {
+    const Model = z.object({
+      name: z.string().nullable(),
+    })
+
+    expect(jsonSchemaFromZod(Model).properties?.["name"]).toEqual({
+      anyOf: [{ type: "string" }, { type: "null" }],
+    })
+    expect(jsonSchemaFromZod(Model).required).toEqual(["name"])
+  })
+
+  it("converts enums, booleans, and floats", () => {
+    const Model = z.object({
+      role: z.enum(["admin", "user"]),
+      active: z.boolean(),
+      score: z.number(),
+    })
+
+    expect(jsonSchemaFromZod(Model).properties).toEqual({
+      role: { type: "string", enum: ["admin", "user"] },
+      active: { type: "boolean" },
+      score: { type: "number" },
+    })
+  })
+
+  it("copies .describe() onto the JSON Schema", () => {
+    const Model = z.object({
+      name: z.string().describe("Display name"),
+    })
+
+    expect(jsonSchemaFromZod(Model).properties?.["name"]).toEqual({
+      type: "string",
+      description: "Display name",
+    })
+  })
+
+  it("throws on unsupported Zod types", () => {
+    expect(() => jsonSchemaFromZod(z.date())).toThrow(/Unsupported Zod type/)
+    expect(() => jsonSchemaFromZod(z.array(z.string()))).toThrow(/Unsupported Zod type/)
+  })
+})


### PR DESCRIPTION
## What
Add `jsonSchemaFromZod()` — a pure converter for the v0 Zod subset (objects including nested, string/number/int/boolean, enum, optional, nullable).

## Why
Roadmap step 2. TOOLS / JSON_SCHEMA / MD_JSON all need JSON Schema before any LLM call.

## Testing
- `pnpm typecheck`
- `pnpm test` (12 tests)

Unsupported types (`z.date()`, arrays, …) throw. No LLM client in this PR.