### PR TITLE
feat: extract structured output via TOOLS mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const user = await client.create({
 
 ## Status
 
-Skeleton only. `wrap()` is exported but not implemented.
+`wrap()` + TOOLS mode work against an `LLMClient` (inject a fake in tests). Reask and a live OpenAI adapter are not implemented yet.
 
 ```bash
 pnpm install

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -1,0 +1,36 @@
+import type { z } from "zod"
+import { SchemaValidationError } from "./errors.ts"
+import { toolsHandler } from "./modes/tools.ts"
+import type { CreateParams, LLMClient, Mode } from "./types.ts"
+
+const DEFAULT_MAX_RETRIES = 3
+const DEFAULT_MODE: Mode = "TOOLS"
+
+export async function extract<T extends z.ZodType>(
+  client: LLMClient,
+  params: CreateParams<T>,
+  defaults?: { mode?: Mode; maxRetries?: number },
+): Promise<z.infer<T>> {
+  const mode = params.mode ?? defaults?.mode ?? DEFAULT_MODE
+  // maxRetries is accepted so wrap() can pass it; reask uses it in a later step.
+  void (params.maxRetries ?? defaults?.maxRetries ?? DEFAULT_MAX_RETRIES)
+
+  if (mode !== "TOOLS") {
+    throw new Error(`Mode "${mode}" is not implemented`)
+  }
+
+  const kwargs = toolsHandler.prepareRequest(params.schema, {
+    model: params.model,
+    messages: params.messages,
+  })
+  const raw = await client.chatCompletionsCreate(kwargs)
+  const json = toolsHandler.parseResponse(raw)
+  const parsed = params.schema.safeParse(json)
+  if (!parsed.success) {
+    throw new SchemaValidationError(
+      "Output failed schema validation",
+      parsed.error.issues,
+    )
+  }
+  return parsed.data
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,12 @@
-import type { RubricClient, WrapOptions } from "./types.ts"
+import { extract } from "./extract.ts"
+import type { LLMClient, RubricClient, WrapOptions } from "./types.ts"
 
 export type {
   CreateParams,
+  LLMClient,
   Message,
   Mode,
+  RequestKwargs,
   RubricClient,
   WrapOptions,
 } from "./types.ts"
@@ -20,9 +23,11 @@ export type { JsonSchema } from "./schema.ts"
 /**
  * Wrap an LLM client with schema-validated create().
  * The original client is not mutated.
- *
- * Not implemented in the skeleton; later steps fill this in.
  */
-export function wrap(_client: unknown, _options?: WrapOptions): RubricClient {
-  throw new Error("wrap() is not implemented")
+export function wrap(client: LLMClient, options?: WrapOptions): RubricClient {
+  return {
+    create(params) {
+      return extract(client, params, options)
+    },
+  }
 }

--- a/src/modes/tools.ts
+++ b/src/modes/tools.ts
@@ -1,0 +1,61 @@
+import type { ZodTypeAny } from "zod"
+import { JsonParseError } from "../errors.ts"
+import { jsonSchemaFromZod } from "../schema.ts"
+import type { RequestKwargs } from "../types.ts"
+import type { ModeHandler } from "./types.ts"
+
+export const EXTRACT_TOOL_NAME = "extract"
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>
+  }
+  return undefined
+}
+
+export const toolsHandler: ModeHandler = {
+  prepareRequest(schema: ZodTypeAny, kwargs: RequestKwargs): RequestKwargs {
+    return {
+      ...kwargs,
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: EXTRACT_TOOL_NAME,
+            description: "Return data that matches the schema.",
+            parameters: jsonSchemaFromZod(schema),
+          },
+        },
+      ],
+      tool_choice: {
+        type: "function",
+        function: { name: EXTRACT_TOOL_NAME },
+      },
+    }
+  },
+
+  parseResponse(raw: unknown): unknown {
+    const root = asRecord(raw)
+    const choices = root?.["choices"]
+    const choice = Array.isArray(choices) ? asRecord(choices[0]) : undefined
+    const message = asRecord(choice?.["message"])
+    const toolCalls = message?.["tool_calls"]
+    const call = Array.isArray(toolCalls) ? asRecord(toolCalls[0]) : undefined
+    const fn = asRecord(call?.["function"])
+    const args = fn?.["arguments"]
+
+    if (typeof args !== "string") {
+      throw new JsonParseError("Response has no tool call arguments", raw)
+    }
+
+    try {
+      return JSON.parse(args) as unknown
+    } catch {
+      throw new JsonParseError("Tool call arguments are not valid JSON", raw)
+    }
+  },
+
+  handleReask(): RequestKwargs {
+    throw new Error("TOOLS reask is not implemented")
+  },
+}

--- a/src/modes/types.ts
+++ b/src/modes/types.ts
@@ -1,0 +1,14 @@
+import type { ZodTypeAny } from "zod"
+import type { JsonParseError, SchemaValidationError } from "../errors.ts"
+import type { RequestKwargs } from "../types.ts"
+
+/** One wire format: how schema is sent, how JSON is read, how errors are attached. */
+export type ModeHandler = {
+  prepareRequest(schema: ZodTypeAny, kwargs: RequestKwargs): RequestKwargs
+  parseResponse(raw: unknown): unknown
+  handleReask(
+    kwargs: RequestKwargs,
+    raw: unknown,
+    error: JsonParseError | SchemaValidationError,
+  ): RequestKwargs
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,20 @@ import type { z } from "zod"
 /** Request encoding used to send the schema and read JSON back. */
 export type Mode = "TOOLS" | "JSON_SCHEMA" | "MD_JSON"
 
+/** Minimal chat-completions surface. Tests inject a fake; a live adapter comes later. */
+export type LLMClient = {
+  chatCompletionsCreate(kwargs: RequestKwargs): Promise<unknown>
+}
+
+/** Arguments passed to the LLM client. Modes add tools / response_format. */
+export type RequestKwargs = {
+  model: string
+  messages: Message[]
+  tools?: unknown
+  tool_choice?: unknown
+  response_format?: unknown
+}
+
 export type Message = {
   role: "system" | "user" | "assistant" | "tool"
   content: string | null

--- a/tests/skeleton.test.ts
+++ b/tests/skeleton.test.ts
@@ -12,8 +12,11 @@ describe("skeleton", () => {
     expect(typeof wrap).toBe("function")
   })
 
-  it("wrap is not implemented yet", () => {
-    expect(() => wrap({})).toThrow(/not implemented/)
+  it("returns a client with create()", () => {
+    const client = wrap({
+      chatCompletionsCreate: async () => ({}),
+    })
+    expect(typeof client.create).toBe("function")
   })
 
   it("constructs JsonParseError with the raw payload", () => {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+import {
+  JsonParseError,
+  SchemaValidationError,
+  wrap,
+  type LLMClient,
+  type RequestKwargs,
+} from "../src/index.ts"
+import { EXTRACT_TOOL_NAME, toolsHandler } from "../src/modes/tools.ts"
+
+const User = z.object({
+  name: z.string(),
+  age: z.number().int(),
+})
+
+function toolResponse(payload: unknown): unknown {
+  return {
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: {
+                name: EXTRACT_TOOL_NAME,
+                arguments: typeof payload === "string" ? payload : JSON.stringify(payload),
+              },
+            },
+          ],
+        },
+      },
+    ],
+  }
+}
+
+function fakeClient(
+  response: unknown,
+  capture: { kwargs?: RequestKwargs } = {},
+): LLMClient {
+  return {
+    async chatCompletionsCreate(kwargs) {
+      capture.kwargs = kwargs
+      return response
+    },
+  }
+}
+
+describe("TOOLS mode", () => {
+  it("extracts a typed object from canned tool_calls", async () => {
+    const client = wrap(fakeClient(toolResponse({ name: "John", age: 25 })))
+    const user = await client.create({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+    })
+    expect(user).toEqual({ name: "John", age: 25 })
+  })
+
+  it("attaches tools and tool_choice on the request", async () => {
+    const capture: { kwargs?: RequestKwargs } = {}
+    const client = wrap(fakeClient(toolResponse({ name: "John", age: 25 }), capture))
+    await client.create({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+    })
+
+    const tools = capture.kwargs?.tools as Array<{
+      function: { name: string; parameters: unknown }
+    }>
+    expect(tools[0]?.function.name).toBe(EXTRACT_TOOL_NAME)
+    expect(tools[0]?.function.parameters).toMatchObject({
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        age: { type: "integer" },
+      },
+    })
+    expect(capture.kwargs?.tool_choice).toEqual({
+      type: "function",
+      function: { name: EXTRACT_TOOL_NAME },
+    })
+  })
+
+  it("throws JsonParseError when tool_calls are missing", async () => {
+    const client = wrap(fakeClient({ choices: [{ message: { content: "hello" } }] }))
+    await expect(
+      client.create({
+        model: "test-model",
+        schema: User,
+        messages: [{ role: "user", content: "John is 25 years old" }],
+      }),
+    ).rejects.toBeInstanceOf(JsonParseError)
+  })
+
+  it("throws SchemaValidationError when JSON does not match the schema", async () => {
+    const client = wrap(fakeClient(toolResponse({ name: "John", age: "twenty-five" })))
+    await expect(
+      client.create({
+        model: "test-model",
+        schema: User,
+        messages: [{ role: "user", content: "John is 25 years old" }],
+      }),
+    ).rejects.toBeInstanceOf(SchemaValidationError)
+  })
+
+  it("does not mutate the original messages array", () => {
+    const messages = [{ role: "user" as const, content: "John is 25 years old" }]
+    const prepared = toolsHandler.prepareRequest(User, {
+      model: "test-model",
+      messages,
+    })
+    expect(prepared.messages).toBe(messages)
+    expect(messages).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## What
Implement TOOLS mode on a fake `LLMClient`: `wrap().create()` prepares `tools` / `tool_choice`, parses `tool_calls[0].function.arguments`, and `safeParse`s the result.

## Why
Roadmap step 3. First complete extract path, still no network.

## Testing
- `pnpm typecheck`
- `pnpm test` (17 tests)

Happy path returns `{ name, age }`. Missing tool calls → `JsonParseError`. Bad types → `SchemaValidationError`. Reask is explicitly not implemented (next PR).