### PR TITLE
feat: reask on parse and validation failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const user = await client.create({
 
 ## Status
 
-`wrap()` + TOOLS mode work against an `LLMClient` (inject a fake in tests). Reask and a live OpenAI adapter are not implemented yet.
+`wrap()` + TOOLS mode work against an `LLMClient` (inject a fake in tests). Parse and validation failures reask until `maxRetries` is exhausted. A live OpenAI adapter is not implemented yet.
 
 ```bash
 pnpm install

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,26 @@
 import type { ZodIssue } from "zod"
 
+/** Short error text attached to the next LLM request. */
+export function formatError(
+  error: JsonParseError | SchemaValidationError,
+): string {
+  if (error instanceof SchemaValidationError) {
+    const lines = error.issues.map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "(root)"
+      return `- ${path}: ${issue.message}`
+    })
+    return [
+      "The previous output failed schema validation:",
+      ...lines,
+      "Fix the JSON and try again.",
+    ].join("\n")
+  }
+  return [
+    "The previous output was not valid JSON.",
+    "Return a single JSON object that matches the schema.",
+  ].join("\n")
+}
+
 /** Thrown when the model response has no JSON, or JSON.parse fails. */
 export class JsonParseError extends Error {
   readonly raw: unknown

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -1,5 +1,9 @@
 import type { z } from "zod"
-import { SchemaValidationError } from "./errors.ts"
+import {
+  JsonParseError,
+  RetryExhaustedError,
+  SchemaValidationError,
+} from "./errors.ts"
 import { toolsHandler } from "./modes/tools.ts"
 import type { CreateParams, LLMClient, Mode } from "./types.ts"
 
@@ -12,25 +16,50 @@ export async function extract<T extends z.ZodType>(
   defaults?: { mode?: Mode; maxRetries?: number },
 ): Promise<z.infer<T>> {
   const mode = params.mode ?? defaults?.mode ?? DEFAULT_MODE
-  // maxRetries is accepted so wrap() can pass it; reask uses it in a later step.
-  void (params.maxRetries ?? defaults?.maxRetries ?? DEFAULT_MAX_RETRIES)
+  const maxRetries = params.maxRetries ?? defaults?.maxRetries ?? DEFAULT_MAX_RETRIES
+  const attemptsAllowed = maxRetries + 1
 
   if (mode !== "TOOLS") {
     throw new Error(`Mode "${mode}" is not implemented`)
   }
 
-  const kwargs = toolsHandler.prepareRequest(params.schema, {
+  const handler = toolsHandler
+  let kwargs = handler.prepareRequest(params.schema, {
     model: params.model,
     messages: params.messages,
   })
-  const raw = await client.chatCompletionsCreate(kwargs)
-  const json = toolsHandler.parseResponse(raw)
-  const parsed = params.schema.safeParse(json)
-  if (!parsed.success) {
-    throw new SchemaValidationError(
-      "Output failed schema validation",
-      parsed.error.issues,
-    )
+  let lastError: JsonParseError | SchemaValidationError | undefined
+  let attempts = 0
+
+  while (attempts < attemptsAllowed) {
+    attempts += 1
+    const raw = await client.chatCompletionsCreate(kwargs)
+
+    try {
+      const json = handler.parseResponse(raw)
+      const parsed = params.schema.safeParse(json)
+      if (!parsed.success) {
+        throw new SchemaValidationError(
+          "Output failed schema validation",
+          parsed.error.issues,
+        )
+      }
+      return parsed.data
+    } catch (err) {
+      if (!(err instanceof JsonParseError || err instanceof SchemaValidationError)) {
+        throw err
+      }
+      lastError = err
+      if (attempts >= attemptsAllowed) {
+        break
+      }
+      kwargs = handler.handleReask(kwargs, raw, err)
+    }
   }
-  return parsed.data
+
+  throw new RetryExhaustedError(
+    `Failed after ${attempts} attempt(s)`,
+    attempts,
+    lastError as JsonParseError | SchemaValidationError,
+  )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,12 @@ export type {
   Mode,
   RequestKwargs,
   RubricClient,
+  ToolCall,
   WrapOptions,
 } from "./types.ts"
 
 export {
+  formatError,
   JsonParseError,
   RetryExhaustedError,
   SchemaValidationError,

--- a/src/modes/tools.ts
+++ b/src/modes/tools.ts
@@ -1,7 +1,11 @@
 import type { ZodTypeAny } from "zod"
-import { JsonParseError } from "../errors.ts"
+import {
+  formatError,
+  JsonParseError,
+  type SchemaValidationError,
+} from "../errors.ts"
 import { jsonSchemaFromZod } from "../schema.ts"
-import type { RequestKwargs } from "../types.ts"
+import type { Message, RequestKwargs, ToolCall } from "../types.ts"
 import type { ModeHandler } from "./types.ts"
 
 export const EXTRACT_TOOL_NAME = "extract"
@@ -55,7 +59,61 @@ export const toolsHandler: ModeHandler = {
     }
   },
 
-  handleReask(): RequestKwargs {
-    throw new Error("TOOLS reask is not implemented")
+  handleReask(
+    kwargs: RequestKwargs,
+    raw: unknown,
+    error: JsonParseError | SchemaValidationError,
+  ): RequestKwargs {
+    const assistant = assistantMessageFromRaw(raw)
+    const toolCallId = assistant.tool_calls?.[0]?.id
+    const followUp: Message = toolCallId
+      ? { role: "tool", tool_call_id: toolCallId, content: formatError(error) }
+      : { role: "user", content: formatError(error) }
+
+    return {
+      ...kwargs,
+      messages: [...kwargs.messages, assistant, followUp],
+    }
   },
+}
+
+function assistantMessageFromRaw(raw: unknown): Message {
+  const root = asRecord(raw)
+  const choices = root?.["choices"]
+  const choice = Array.isArray(choices) ? asRecord(choices[0]) : undefined
+  const message = asRecord(choice?.["message"])
+  const content = message?.["content"]
+  const toolCalls = readToolCalls(message?.["tool_calls"])
+
+  const assistant: Message = {
+    role: "assistant",
+    content: typeof content === "string" || content === null ? content : null,
+  }
+  if (toolCalls) {
+    assistant.tool_calls = toolCalls
+  }
+  return assistant
+}
+
+function readToolCalls(value: unknown): ToolCall[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined
+  }
+  const calls: ToolCall[] = []
+  for (const item of value) {
+    const call = asRecord(item)
+    const fn = asRecord(call?.["function"])
+    const id = call?.["id"]
+    const name = fn?.["name"]
+    const args = fn?.["arguments"]
+    if (typeof id !== "string" || typeof name !== "string" || typeof args !== "string") {
+      continue
+    }
+    calls.push({
+      id,
+      type: "function",
+      function: { name, arguments: args },
+    })
+  }
+  return calls.length > 0 ? calls : undefined
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,10 +17,20 @@ export type RequestKwargs = {
   response_format?: unknown
 }
 
+export type ToolCall = {
+  id: string
+  type: "function"
+  function: {
+    name: string
+    arguments: string
+  }
+}
+
 export type Message = {
   role: "system" | "user" | "assistant" | "tool"
   content: string | null
   tool_call_id?: string
+  tool_calls?: ToolCall[]
 }
 
 export type WrapOptions = {

--- a/tests/reask.test.ts
+++ b/tests/reask.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+import {
+  SchemaValidationError,
+  wrap,
+  type LLMClient,
+  type Message,
+  type RequestKwargs,
+} from "../src/index.ts"
+import { EXTRACT_TOOL_NAME, toolsHandler } from "../src/modes/tools.ts"
+
+const User = z.object({
+  name: z.string(),
+  age: z.number().int(),
+})
+
+function toolResponse(payload: unknown, id = "call_1"): unknown {
+  return {
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id,
+              type: "function",
+              function: {
+                name: EXTRACT_TOOL_NAME,
+                arguments:
+                  typeof payload === "string" ? payload : JSON.stringify(payload),
+              },
+            },
+          ],
+        },
+      },
+    ],
+  }
+}
+
+function sequenceClient(
+  responses: unknown[],
+  capture: RequestKwargs[] = [],
+): LLMClient {
+  let index = 0
+  return {
+    async chatCompletionsCreate(kwargs) {
+      capture.push(kwargs)
+      const next = responses[index]
+      index += 1
+      if (next instanceof Error) {
+        throw next
+      }
+      return next
+    },
+  }
+}
+
+describe("reask", () => {
+  it("retries after invalid JSON and succeeds on the next tool call", async () => {
+    const capture: RequestKwargs[] = []
+    const client = wrap(
+      sequenceClient(
+        [
+          toolResponse({ name: "John", age: "twenty-five" }, "call_1"),
+          toolResponse({ name: "John", age: 25 }, "call_2"),
+        ],
+        capture,
+      ),
+    )
+
+    const user = await client.create({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+    })
+    expect(user).toEqual({ name: "John", age: 25 })
+    expect(capture).toHaveLength(2)
+
+    const second = capture[1]
+    const roles = second?.messages.map((message) => message.role)
+    expect(roles).toEqual(["user", "assistant", "tool"])
+    const tool = second?.messages.find((message) => message.role === "tool")
+    expect(tool?.tool_call_id).toBe("call_1")
+    expect(tool?.content).toMatch(/failed schema validation/)
+    expect(tool?.content).toMatch(/age/)
+    expect(second?.tool_choice).toEqual({
+      type: "function",
+      function: { name: EXTRACT_TOOL_NAME },
+    })
+  })
+
+  it("succeeds after two failures when maxRetries is 2", async () => {
+    const capture: RequestKwargs[] = []
+    const client = wrap(
+      sequenceClient(
+        [
+          toolResponse({ name: "John" }, "call_1"),
+          toolResponse("not-json", "call_2"),
+          toolResponse({ name: "John", age: 25 }, "call_3"),
+        ],
+        capture,
+      ),
+    )
+
+    const user = await client.create({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+      maxRetries: 2,
+    })
+    expect(user).toEqual({ name: "John", age: 25 })
+    expect(capture).toHaveLength(3)
+  })
+
+  it("does not retry SDK errors", async () => {
+    const capture: RequestKwargs[] = []
+    const boom = new Error("network down")
+    const client = wrap(sequenceClient([boom], capture))
+
+    await expect(
+      client.create({
+        model: "test-model",
+        schema: User,
+        messages: [{ role: "user", content: "John is 25 years old" }],
+        maxRetries: 3,
+      }),
+    ).rejects.toBe(boom)
+    expect(capture).toHaveLength(1)
+  })
+
+  it("does not mutate the original messages when reasking", () => {
+    const messages: Message[] = [{ role: "user", content: "John is 25 years old" }]
+    const prepared = toolsHandler.prepareRequest(User, {
+      model: "test-model",
+      messages,
+    })
+    const next = toolsHandler.handleReask(
+      prepared,
+      toolResponse({ name: "John", age: "x" }, "call_1"),
+      new SchemaValidationError("invalid", []),
+    )
+    expect(messages).toHaveLength(1)
+    expect(next.messages).not.toBe(messages)
+    expect(next.messages.length).toBeGreaterThan(messages.length)
+  })
+})

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import { z } from "zod"
 import {
   JsonParseError,
+  RetryExhaustedError,
   SchemaValidationError,
   wrap,
   type LLMClient,
@@ -86,26 +87,33 @@ describe("TOOLS mode", () => {
     })
   })
 
-  it("throws JsonParseError when tool_calls are missing", async () => {
+  it("throws RetryExhaustedError when tool_calls are missing and retries are 0", async () => {
     const client = wrap(fakeClient({ choices: [{ message: { content: "hello" } }] }))
-    await expect(
-      client.create({
+    const err = await client
+      .create({
         model: "test-model",
         schema: User,
         messages: [{ role: "user", content: "John is 25 years old" }],
-      }),
-    ).rejects.toBeInstanceOf(JsonParseError)
+        maxRetries: 0,
+      })
+      .catch((caught: unknown) => caught)
+    expect(err).toBeInstanceOf(RetryExhaustedError)
+    expect((err as RetryExhaustedError).attempts).toBe(1)
+    expect((err as RetryExhaustedError).lastError).toBeInstanceOf(JsonParseError)
   })
 
-  it("throws SchemaValidationError when JSON does not match the schema", async () => {
+  it("throws RetryExhaustedError when JSON does not match and retries are 0", async () => {
     const client = wrap(fakeClient(toolResponse({ name: "John", age: "twenty-five" })))
-    await expect(
-      client.create({
+    const err = await client
+      .create({
         model: "test-model",
         schema: User,
         messages: [{ role: "user", content: "John is 25 years old" }],
-      }),
-    ).rejects.toBeInstanceOf(SchemaValidationError)
+        maxRetries: 0,
+      })
+      .catch((caught: unknown) => caught)
+    expect(err).toBeInstanceOf(RetryExhaustedError)
+    expect((err as RetryExhaustedError).lastError).toBeInstanceOf(SchemaValidationError)
   })
 
   it("does not mutate the original messages array", () => {


### PR DESCRIPTION
## What
Add the TOOLS reask loop: on JSON/schema failure, append the assistant tool call plus a `role: tool` error, then call the LLM again. Exhausted retries throw `RetryExhaustedError`.

## Why
Roadmap step 4. This is the extract loop that makes structured output reliable.

## Testing
- `pnpm typecheck`
- `pnpm test` (21 tests)

Covers first-fail-then-succeed, two failures then success (`maxRetries: 2`), `maxRetries: 0` → exhausted, and SDK errors not retried. Still no live API.