### PR TITLE
feat: add JSON_SCHEMA and MD_JSON modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const user = await client.create({
 
 ## Status
 
-`wrap()` + TOOLS mode work against an `LLMClient` (inject a fake in tests). Parse and validation failures reask until `maxRetries` is exhausted. A live OpenAI adapter is not implemented yet.
+`wrap()` works against an `LLMClient` (inject a fake in tests) in `TOOLS`, `JSON_SCHEMA`, and `MD_JSON`. Parse and validation failures reask until `maxRetries` is exhausted. A live OpenAI adapter is not implemented yet.
 
 ```bash
 pnpm install

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -4,7 +4,7 @@ import {
   RetryExhaustedError,
   SchemaValidationError,
 } from "./errors.ts"
-import { toolsHandler } from "./modes/tools.ts"
+import { handlerFor } from "./modes/registry.ts"
 import type { CreateParams, LLMClient, Mode } from "./types.ts"
 
 const DEFAULT_MAX_RETRIES = 3
@@ -18,12 +18,7 @@ export async function extract<T extends z.ZodType>(
   const mode = params.mode ?? defaults?.mode ?? DEFAULT_MODE
   const maxRetries = params.maxRetries ?? defaults?.maxRetries ?? DEFAULT_MAX_RETRIES
   const attemptsAllowed = maxRetries + 1
-
-  if (mode !== "TOOLS") {
-    throw new Error(`Mode "${mode}" is not implemented`)
-  }
-
-  const handler = toolsHandler
+  const handler = handlerFor(mode)
   let kwargs = handler.prepareRequest(params.schema, {
     model: params.model,
     messages: params.messages,

--- a/src/modes/helpers.ts
+++ b/src/modes/helpers.ts
@@ -1,0 +1,83 @@
+import { formatError, JsonParseError, type SchemaValidationError } from "../errors.ts"
+import type { Message, RequestKwargs, ToolCall } from "../types.ts"
+
+export const EXTRACT_NAME = "extract"
+
+export function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>
+  }
+  return undefined
+}
+
+export function choiceMessage(raw: unknown): Record<string, unknown> | undefined {
+  const root = asRecord(raw)
+  const choices = root?.["choices"]
+  const choice = Array.isArray(choices) ? asRecord(choices[0]) : undefined
+  return asRecord(choice?.["message"])
+}
+
+export function assistantMessageFromRaw(raw: unknown): Message {
+  const message = choiceMessage(raw)
+  const content = message?.["content"]
+  const toolCalls = readToolCalls(message?.["tool_calls"])
+  const assistant: Message = {
+    role: "assistant",
+    content: typeof content === "string" || content === null ? content : null,
+  }
+  if (toolCalls) {
+    assistant.tool_calls = toolCalls
+  }
+  return assistant
+}
+
+export function readToolCalls(value: unknown): ToolCall[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined
+  }
+  const calls: ToolCall[] = []
+  for (const item of value) {
+    const call = asRecord(item)
+    const fn = asRecord(call?.["function"])
+    const id = call?.["id"]
+    const name = fn?.["name"]
+    const args = fn?.["arguments"]
+    if (typeof id !== "string" || typeof name !== "string" || typeof args !== "string") {
+      continue
+    }
+    calls.push({
+      id,
+      type: "function",
+      function: { name, arguments: args },
+    })
+  }
+  return calls.length > 0 ? calls : undefined
+}
+
+export function parseJsonText(
+  text: string,
+  raw: unknown,
+  message = "Message content is not valid JSON",
+): unknown {
+  try {
+    return JSON.parse(text) as unknown
+  } catch {
+    throw new JsonParseError(message, raw)
+  }
+}
+
+/** Reask by appending the assistant output and a user error message. */
+export function reaskWithUserMessage(
+  kwargs: RequestKwargs,
+  raw: unknown,
+  error: JsonParseError | SchemaValidationError,
+): RequestKwargs {
+  return {
+    ...kwargs,
+    messages: [
+      ...kwargs.messages,
+      assistantMessageFromRaw(raw),
+      { role: "user", content: formatError(error) },
+    ],
+  }
+}

--- a/src/modes/json-schema.ts
+++ b/src/modes/json-schema.ts
@@ -1,0 +1,43 @@
+import type { ZodTypeAny } from "zod"
+import { JsonParseError, type SchemaValidationError } from "../errors.ts"
+import { jsonSchemaFromZod } from "../schema.ts"
+import type { RequestKwargs } from "../types.ts"
+import {
+  choiceMessage,
+  EXTRACT_NAME,
+  parseJsonText,
+  reaskWithUserMessage,
+} from "./helpers.ts"
+import type { ModeHandler } from "./types.ts"
+
+export const jsonSchemaHandler: ModeHandler = {
+  prepareRequest(schema: ZodTypeAny, kwargs: RequestKwargs): RequestKwargs {
+    return {
+      ...kwargs,
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: EXTRACT_NAME,
+          strict: true,
+          schema: jsonSchemaFromZod(schema),
+        },
+      },
+    }
+  },
+
+  parseResponse(raw: unknown): unknown {
+    const content = choiceMessage(raw)?.["content"]
+    if (typeof content !== "string" || content.trim() === "") {
+      throw new JsonParseError("Response has no JSON content", raw)
+    }
+    return parseJsonText(content, raw)
+  },
+
+  handleReask(
+    kwargs: RequestKwargs,
+    raw: unknown,
+    error: JsonParseError | SchemaValidationError,
+  ): RequestKwargs {
+    return reaskWithUserMessage(kwargs, raw, error)
+  },
+}

--- a/src/modes/md-json.ts
+++ b/src/modes/md-json.ts
@@ -1,0 +1,60 @@
+import type { ZodTypeAny } from "zod"
+import { JsonParseError, type SchemaValidationError } from "../errors.ts"
+import { jsonSchemaFromZod } from "../schema.ts"
+import type { RequestKwargs } from "../types.ts"
+import { choiceMessage, parseJsonText, reaskWithUserMessage } from "./helpers.ts"
+import type { ModeHandler } from "./types.ts"
+
+const FENCE = /```(?:json)?\s*([\s\S]*?)```/i
+
+function instruction(schema: ZodTypeAny): string {
+  const jsonSchema = JSON.stringify(jsonSchemaFromZod(schema), null, 2)
+  return [
+    "Reply with only a JSON object inside a markdown fence:",
+    "",
+    "```json",
+    "{ ... }",
+    "```",
+    "",
+    "The JSON must match this schema:",
+    jsonSchema,
+  ].join("\n")
+}
+
+export const mdJsonHandler: ModeHandler = {
+  prepareRequest(schema: ZodTypeAny, kwargs: RequestKwargs): RequestKwargs {
+    return {
+      ...kwargs,
+      messages: [
+        { role: "system", content: instruction(schema) },
+        ...kwargs.messages,
+      ],
+    }
+  },
+
+  parseResponse(raw: unknown): unknown {
+    const content = choiceMessage(raw)?.["content"]
+    if (typeof content !== "string" || content.trim() === "") {
+      throw new JsonParseError("Response has no JSON content", raw)
+    }
+
+    const fenced = content.match(FENCE)
+    if (fenced?.[1] !== undefined) {
+      try {
+        return JSON.parse(fenced[1]) as unknown
+      } catch {
+        // Fall through and try the full message.
+      }
+    }
+
+    return parseJsonText(content, raw)
+  },
+
+  handleReask(
+    kwargs: RequestKwargs,
+    raw: unknown,
+    error: JsonParseError | SchemaValidationError,
+  ): RequestKwargs {
+    return reaskWithUserMessage(kwargs, raw, error)
+  },
+}

--- a/src/modes/registry.ts
+++ b/src/modes/registry.ts
@@ -1,0 +1,16 @@
+import type { Mode } from "../types.ts"
+import { jsonSchemaHandler } from "./json-schema.ts"
+import { mdJsonHandler } from "./md-json.ts"
+import { toolsHandler } from "./tools.ts"
+import type { ModeHandler } from "./types.ts"
+
+export function handlerFor(mode: Mode): ModeHandler {
+  switch (mode) {
+    case "TOOLS":
+      return toolsHandler
+    case "JSON_SCHEMA":
+      return jsonSchemaHandler
+    case "MD_JSON":
+      return mdJsonHandler
+  }
+}

--- a/src/modes/tools.ts
+++ b/src/modes/tools.ts
@@ -5,17 +5,18 @@ import {
   type SchemaValidationError,
 } from "../errors.ts"
 import { jsonSchemaFromZod } from "../schema.ts"
-import type { Message, RequestKwargs, ToolCall } from "../types.ts"
+import type { Message, RequestKwargs } from "../types.ts"
+import {
+  asRecord,
+  assistantMessageFromRaw,
+  choiceMessage,
+  EXTRACT_NAME,
+  parseJsonText,
+  readToolCalls,
+} from "./helpers.ts"
 import type { ModeHandler } from "./types.ts"
 
-export const EXTRACT_TOOL_NAME = "extract"
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
-    return value as Record<string, unknown>
-  }
-  return undefined
-}
+export const EXTRACT_TOOL_NAME = EXTRACT_NAME
 
 export const toolsHandler: ModeHandler = {
   prepareRequest(schema: ZodTypeAny, kwargs: RequestKwargs): RequestKwargs {
@@ -25,7 +26,7 @@ export const toolsHandler: ModeHandler = {
         {
           type: "function",
           function: {
-            name: EXTRACT_TOOL_NAME,
+            name: EXTRACT_NAME,
             description: "Return data that matches the schema.",
             parameters: jsonSchemaFromZod(schema),
           },
@@ -33,16 +34,13 @@ export const toolsHandler: ModeHandler = {
       ],
       tool_choice: {
         type: "function",
-        function: { name: EXTRACT_TOOL_NAME },
+        function: { name: EXTRACT_NAME },
       },
     }
   },
 
   parseResponse(raw: unknown): unknown {
-    const root = asRecord(raw)
-    const choices = root?.["choices"]
-    const choice = Array.isArray(choices) ? asRecord(choices[0]) : undefined
-    const message = asRecord(choice?.["message"])
+    const message = choiceMessage(raw)
     const toolCalls = message?.["tool_calls"]
     const call = Array.isArray(toolCalls) ? asRecord(toolCalls[0]) : undefined
     const fn = asRecord(call?.["function"])
@@ -52,11 +50,7 @@ export const toolsHandler: ModeHandler = {
       throw new JsonParseError("Response has no tool call arguments", raw)
     }
 
-    try {
-      return JSON.parse(args) as unknown
-    } catch {
-      throw new JsonParseError("Tool call arguments are not valid JSON", raw)
-    }
+    return parseJsonText(args, raw, "Tool call arguments are not valid JSON")
   },
 
   handleReask(
@@ -65,7 +59,7 @@ export const toolsHandler: ModeHandler = {
     error: JsonParseError | SchemaValidationError,
   ): RequestKwargs {
     const assistant = assistantMessageFromRaw(raw)
-    const toolCallId = assistant.tool_calls?.[0]?.id
+    const toolCallId = readToolCalls(choiceMessage(raw)?.["tool_calls"])?.[0]?.id
     const followUp: Message = toolCallId
       ? { role: "tool", tool_call_id: toolCallId, content: formatError(error) }
       : { role: "user", content: formatError(error) }
@@ -75,45 +69,4 @@ export const toolsHandler: ModeHandler = {
       messages: [...kwargs.messages, assistant, followUp],
     }
   },
-}
-
-function assistantMessageFromRaw(raw: unknown): Message {
-  const root = asRecord(raw)
-  const choices = root?.["choices"]
-  const choice = Array.isArray(choices) ? asRecord(choices[0]) : undefined
-  const message = asRecord(choice?.["message"])
-  const content = message?.["content"]
-  const toolCalls = readToolCalls(message?.["tool_calls"])
-
-  const assistant: Message = {
-    role: "assistant",
-    content: typeof content === "string" || content === null ? content : null,
-  }
-  if (toolCalls) {
-    assistant.tool_calls = toolCalls
-  }
-  return assistant
-}
-
-function readToolCalls(value: unknown): ToolCall[] | undefined {
-  if (!Array.isArray(value)) {
-    return undefined
-  }
-  const calls: ToolCall[] = []
-  for (const item of value) {
-    const call = asRecord(item)
-    const fn = asRecord(call?.["function"])
-    const id = call?.["id"]
-    const name = fn?.["name"]
-    const args = fn?.["arguments"]
-    if (typeof id !== "string" || typeof name !== "string" || typeof args !== "string") {
-      continue
-    }
-    calls.push({
-      id,
-      type: "function",
-      function: { name, arguments: args },
-    })
-  }
-  return calls.length > 0 ? calls : undefined
 }

--- a/tests/content-modes.test.ts
+++ b/tests/content-modes.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+import {
+  wrap,
+  type LLMClient,
+  type RequestKwargs,
+} from "../src/index.ts"
+
+const User = z.object({
+  name: z.string(),
+  age: z.number().int(),
+})
+
+function contentResponse(content: string): unknown {
+  return {
+    choices: [{ message: { role: "assistant", content } }],
+  }
+}
+
+function sequenceClient(
+  responses: unknown[],
+  capture: RequestKwargs[] = [],
+): LLMClient {
+  let index = 0
+  return {
+    async chatCompletionsCreate(kwargs) {
+      capture.push(kwargs)
+      return responses[index++]
+    },
+  }
+}
+
+describe("JSON_SCHEMA mode", () => {
+  it("extracts a User from message content", async () => {
+    const capture: RequestKwargs[] = []
+    const client = wrap(
+      sequenceClient(
+        [contentResponse(JSON.stringify({ name: "John", age: 25 }))],
+        capture,
+      ),
+      { mode: "JSON_SCHEMA" },
+    )
+
+    const user = await client.create({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+    })
+    expect(user).toEqual({ name: "John", age: 25 })
+    expect(capture[0]?.response_format).toMatchObject({
+      type: "json_schema",
+      json_schema: {
+        name: "extract",
+        strict: true,
+        schema: { type: "object" },
+      },
+    })
+  })
+
+  it("reasks with a user error message", async () => {
+    const capture: RequestKwargs[] = []
+    const client = wrap(
+      sequenceClient(
+        [
+          contentResponse(JSON.stringify({ name: "John", age: "x" })),
+          contentResponse(JSON.stringify({ name: "John", age: 25 })),
+        ],
+        capture,
+      ),
+      { mode: "JSON_SCHEMA" },
+    )
+
+    const user = await client.create({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+    })
+    expect(user).toEqual({ name: "John", age: 25 })
+    expect(capture[1]?.messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+    ])
+    expect(capture[1]?.messages.at(-1)?.content).toMatch(/failed schema validation/)
+  })
+})
+
+describe("MD_JSON mode", () => {
+  it("reads JSON from a markdown fence", async () => {
+    const capture: RequestKwargs[] = []
+    const client = wrap(
+      sequenceClient(
+        [
+          contentResponse(
+            'Sure:\n```json\n{"name":"John","age":25}\n```\n',
+          ),
+        ],
+        capture,
+      ),
+      { mode: "MD_JSON" },
+    )
+
+    const user = await client.create({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+    })
+    expect(user).toEqual({ name: "John", age: 25 })
+    expect(capture[0]?.messages[0]?.role).toBe("system")
+    expect(capture[0]?.messages[0]?.content).toMatch(/markdown fence/)
+  })
+
+  it("reads raw JSON when there is no fence", async () => {
+    const client = wrap(
+      sequenceClient([contentResponse('{"name":"John","age":25}')]),
+      { mode: "MD_JSON" },
+    )
+    const user = await client.create({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+    })
+    expect(user).toEqual({ name: "John", age: 25 })
+  })
+
+  it("ignores surrounding prose when a fence is present", async () => {
+    const client = wrap(
+      sequenceClient([
+        contentResponse('Here you go:\n```json\n{"name":"John","age":25}\n```\nThanks.'),
+      ]),
+      { mode: "MD_JSON" },
+    )
+    const user = await client.create({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+    })
+    expect(user).toEqual({ name: "John", age: 25 })
+  })
+})


### PR DESCRIPTION
## What
Add `JSON_SCHEMA` and `MD_JSON` handlers on the same extract/reask loop as TOOLS.

- JSON_SCHEMA: `response_format.json_schema` + parse `message.content`
- MD_JSON: system instruction + parse a markdown fence (fallback: raw JSON)
- Reask for both: append assistant output and a user error message

## Why
Roadmap step 5. All three v0 modes should run the same User extract against a fake client.

## Testing
- `pnpm typecheck`
- `pnpm test` (26 tests)

Still no live OpenAI adapter.