### PR TITLE
feat: support Zod arrays in schema conversion and extract

### DIFF
--- a/src/extract.ts
+++ b/src/extract.ts
@@ -5,6 +5,7 @@ import {
   SchemaValidationError,
 } from "./errors.ts"
 import { handlerFor } from "./modes/registry.ts"
+import { coerceParsedValue } from "./schema.ts"
 import type { CreateParams, LLMClient, Mode } from "./types.ts"
 
 const DEFAULT_MAX_RETRIES = 3
@@ -31,7 +32,7 @@ export async function extract<T extends z.ZodType>(
     const raw = await client.chatCompletionsCreate(kwargs)
 
     try {
-      const json = handler.parseResponse(raw)
+      const json = coerceParsedValue(params.schema, handler.parseResponse(raw))
       const parsed = params.schema.safeParse(json)
       if (!parsed.success) {
         throw new SchemaValidationError(

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export {
   SchemaValidationError,
 } from "./errors.ts"
 
-export { jsonSchemaFromZod } from "./schema.ts"
+export { coerceParsedValue, jsonSchemaFromZod, llmJsonSchemaFromZod } from "./schema.ts"
 export type { JsonSchema } from "./schema.ts"
 export type { OpenAIChatClient } from "./adapters/openai.ts"
 

--- a/src/modes/json-schema.ts
+++ b/src/modes/json-schema.ts
@@ -1,6 +1,6 @@
 import type { ZodTypeAny } from "zod"
 import { JsonParseError, type SchemaValidationError } from "../errors.ts"
-import { jsonSchemaFromZod } from "../schema.ts"
+import { llmJsonSchemaFromZod } from "../schema.ts"
 import type { RequestKwargs } from "../types.ts"
 import {
   choiceMessage,
@@ -19,7 +19,7 @@ export const jsonSchemaHandler: ModeHandler = {
         json_schema: {
           name: EXTRACT_NAME,
           strict: true,
-          schema: jsonSchemaFromZod(schema),
+          schema: llmJsonSchemaFromZod(schema),
         },
       },
     }

--- a/src/modes/md-json.ts
+++ b/src/modes/md-json.ts
@@ -10,10 +10,10 @@ const FENCE = /```(?:json)?\s*([\s\S]*?)```/i
 function instruction(schema: ZodTypeAny): string {
   const jsonSchema = JSON.stringify(jsonSchemaFromZod(schema), null, 2)
   return [
-    "Reply with only a JSON object inside a markdown fence:",
+    "Reply with only JSON inside a markdown fence:",
     "",
     "```json",
-    "{ ... }",
+    "...",
     "```",
     "",
     "The JSON must match this schema:",

--- a/src/modes/tools.ts
+++ b/src/modes/tools.ts
@@ -4,7 +4,7 @@ import {
   JsonParseError,
   type SchemaValidationError,
 } from "../errors.ts"
-import { jsonSchemaFromZod } from "../schema.ts"
+import { llmJsonSchemaFromZod } from "../schema.ts"
 import type { Message, RequestKwargs } from "../types.ts"
 import {
   asRecord,
@@ -28,7 +28,7 @@ export const toolsHandler: ModeHandler = {
           function: {
             name: EXTRACT_NAME,
             description: "Return data that matches the schema.",
-            parameters: jsonSchemaFromZod(schema),
+            parameters: llmJsonSchemaFromZod(schema),
           },
         },
       ],

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -6,6 +6,7 @@ export type JsonSchema = {
   properties?: Record<string, JsonSchema>
   required?: string[]
   additionalProperties?: boolean
+  items?: JsonSchema
   enum?: Array<string | number | null>
   description?: string
   anyOf?: JsonSchema[]
@@ -28,7 +29,7 @@ function def(schema: ZodTypeAny): ZodDef {
 /**
  * Convert a Zod schema into JSON Schema.
  *
- * v0 supports objects (including nested), string, number, int, boolean,
+ * Supports objects (including nested), arrays, string, number, int, boolean,
  * enum, optional, and nullable. Other Zod types throw.
  */
 export function jsonSchemaFromZod(schema: ZodTypeAny): JsonSchema {
@@ -104,11 +105,52 @@ function convert(schema: ZodTypeAny): JsonSchema {
       return { type: "string", enum: [...(def(schema).values ?? [])] }
     case "ZodObject":
       return convertObject(schema as z.ZodObject<z.ZodRawShape>)
+    case "ZodArray": {
+      const element = def(schema).type as ZodTypeAny
+      return { type: "array", items: jsonSchemaFromZod(element) }
+    }
     default:
       throw new Error(
-        `Unsupported Zod type "${typeName}". v0 supports object, string, number, int, boolean, enum, optional, and nullable.`,
+        `Unsupported Zod type "${typeName}". Supported: object, array, string, number, int, boolean, enum, optional, nullable.`,
       )
   }
+}
+
+const ROOT_ARRAY_KEY = "items"
+
+/**
+ * OpenAI tools / json_schema require a root object.
+ * Root arrays are wrapped as `{ items: T[] }`.
+ */
+export function llmJsonSchemaFromZod(schema: ZodTypeAny): JsonSchema {
+  const json = jsonSchemaFromZod(schema)
+  if (json.type !== "array") {
+    return json
+  }
+  return {
+    type: "object",
+    properties: { [ROOT_ARRAY_KEY]: json },
+    required: [ROOT_ARRAY_KEY],
+    additionalProperties: false,
+  }
+}
+
+/** If the schema is a root array, accept either `T[]` or `{ items: T[] }`. */
+export function coerceParsedValue(schema: ZodTypeAny, json: unknown): unknown {
+  if (!isRootArray(schema)) {
+    return json
+  }
+  if (Array.isArray(json)) {
+    return json
+  }
+  if (json !== null && typeof json === "object" && ROOT_ARRAY_KEY in json) {
+    return (json as { items: unknown }).items
+  }
+  return json
+}
+
+function isRootArray(schema: ZodTypeAny): boolean {
+  return def(unwrap(schema).inner).typeName === "ZodArray"
 }
 
 function convertObject(schema: z.ZodObject<z.ZodRawShape>): JsonSchema {

--- a/tests/array.test.ts
+++ b/tests/array.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+import { wrap, type LLMClient, type RequestKwargs } from "../src/index.ts"
+import { EXTRACT_TOOL_NAME } from "../src/modes/tools.ts"
+
+const User = z.object({
+  name: z.string(),
+  age: z.number().int(),
+})
+const Users = z.array(User)
+const people = [
+  { name: "John", age: 25 },
+  { name: "Jane", age: 30 },
+]
+
+function toolResponse(payload: unknown): unknown {
+  return {
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: {
+                name: EXTRACT_TOOL_NAME,
+                arguments: JSON.stringify(payload),
+              },
+            },
+          ],
+        },
+      },
+    ],
+  }
+}
+
+function contentResponse(content: unknown): unknown {
+  return {
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: typeof content === "string" ? content : JSON.stringify(content),
+        },
+      },
+    ],
+  }
+}
+
+function fakeClient(response: unknown, capture: RequestKwargs[] = []): LLMClient {
+  return {
+    async chatCompletionsCreate(kwargs) {
+      capture.push(kwargs)
+      return response
+    },
+  }
+}
+
+describe("array extract", () => {
+  it("TOOLS: extracts User[] from a wrapped { items } payload", async () => {
+    const capture: RequestKwargs[] = []
+    const client = wrap(fakeClient(toolResponse({ items: people }), capture))
+    const users = await client.create({
+      model: "test-model",
+      schema: Users,
+      messages: [{ role: "user", content: "John is 25 and Jane is 30" }],
+    })
+    expect(users).toEqual(people)
+    const tools = capture[0]?.tools as Array<{ function: { parameters: { type: string } } }>
+    expect(tools[0]?.function.parameters.type).toBe("object")
+  })
+
+  it("JSON_SCHEMA: extracts User[] from { items }", async () => {
+    const client = wrap(fakeClient(contentResponse({ items: people })), {
+      mode: "JSON_SCHEMA",
+    })
+    const users = await client.create({
+      model: "test-model",
+      schema: Users,
+      messages: [{ role: "user", content: "John is 25 and Jane is 30" }],
+    })
+    expect(users).toEqual(people)
+  })
+
+  it("MD_JSON: extracts User[] from a raw JSON array", async () => {
+    const client = wrap(fakeClient(contentResponse(people)), { mode: "MD_JSON" })
+    const users = await client.create({
+      model: "test-model",
+      schema: Users,
+      messages: [{ role: "user", content: "John is 25 and Jane is 30" }],
+    })
+    expect(users).toEqual(people)
+  })
+
+  it("extracts an object that contains an array field", async () => {
+    const Team = z.object({
+      members: z.array(User),
+    })
+    const client = wrap(
+      fakeClient(toolResponse({ members: people })),
+    )
+    const team = await client.create({
+      model: "test-model",
+      schema: Team,
+      messages: [{ role: "user", content: "John is 25 and Jane is 30" }],
+    })
+    expect(team.members).toEqual(people)
+  })
+})

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { z } from "zod"
-import { jsonSchemaFromZod } from "../src/schema.ts"
+import { jsonSchemaFromZod, llmJsonSchemaFromZod } from "../src/schema.ts"
 
 describe("jsonSchemaFromZod", () => {
   it("converts a flat object with string and int", () => {
@@ -91,8 +91,64 @@ describe("jsonSchemaFromZod", () => {
     })
   })
 
+  it("converts arrays of primitives and objects", () => {
+    expect(jsonSchemaFromZod(z.array(z.string()))).toEqual({
+      type: "array",
+      items: { type: "string" },
+    })
+
+    const Users = z.array(
+      z.object({
+        name: z.string(),
+        age: z.number().int(),
+      }),
+    )
+    expect(jsonSchemaFromZod(Users)).toEqual({
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          name: { type: "string" },
+          age: { type: "integer" },
+        },
+        required: ["name", "age"],
+      },
+    })
+  })
+
+  it("converts nested and optional arrays on objects", () => {
+    const Model = z.object({
+      tags: z.array(z.string()),
+      groups: z.array(z.array(z.number())).optional(),
+    })
+    const schema = jsonSchemaFromZod(Model)
+    expect(schema.properties?.["tags"]).toEqual({
+      type: "array",
+      items: { type: "string" },
+    })
+    expect(schema.properties?.["groups"]).toEqual({
+      type: "array",
+      items: { type: "array", items: { type: "number" } },
+    })
+    expect(schema.required).toEqual(["tags"])
+  })
+
+  it("wraps a root array as { items } for LLM object roots", () => {
+    expect(llmJsonSchemaFromZod(z.array(z.string()))).toEqual({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        items: { type: "array", items: { type: "string" } },
+      },
+      required: ["items"],
+    })
+  })
+
   it("throws on unsupported Zod types", () => {
     expect(() => jsonSchemaFromZod(z.date())).toThrow(/Unsupported Zod type/)
-    expect(() => jsonSchemaFromZod(z.array(z.string()))).toThrow(/Unsupported Zod type/)
+    expect(() => jsonSchemaFromZod(z.map(z.string(), z.string()))).toThrow(
+      /Unsupported Zod type/,
+    )
   })
 })


### PR DESCRIPTION
## What
Support `z.array` (including nested and optional arrays). Root arrays are wrapped as `{ items: T[] }` for TOOLS / JSON_SCHEMA (OpenAI wants an object root). Parsed `{ items }` or a raw array both coerce back to `T[]`.

## Why
Roadmap step 12. Extracting lists was the first hole after v0.

## Testing
- `pnpm typecheck`
- `pnpm test` (35 tests)

Still unsupported: `z.date()`, maps, recursive schemas.