### PR TITLE
feat: add maybe() for optional extraction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export {
 export { coerceParsedValue, jsonSchemaFromZod, llmJsonSchemaFromZod } from "./schema.ts"
 export type { JsonSchema } from "./schema.ts"
 export type { OpenAIChatClient } from "./adapters/openai.ts"
+export { maybe } from "./maybe.ts"
 
 /**
  * Wrap an LLM client with schema-validated create().

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -1,0 +1,21 @@
+import { z, type ZodTypeAny } from "zod"
+
+/**
+ * Wrap a schema so extraction can report a miss instead of failing.
+ *
+ * Use as `create({ schema: maybe(User), ... })`.
+ */
+export function maybe<T extends ZodTypeAny>(schema: T) {
+  return z.object({
+    result: schema
+      .nullable()
+      .describe("Extracted value if present in the input, otherwise null"),
+    error: z
+      .boolean()
+      .describe("True when no value could be extracted from the input"),
+    message: z
+      .string()
+      .nullable()
+      .describe("Short reason when error is true, otherwise null"),
+  })
+}

--- a/tests/maybe.test.ts
+++ b/tests/maybe.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+import { maybe, wrap, type LLMClient } from "../src/index.ts"
+import { EXTRACT_TOOL_NAME } from "../src/modes/tools.ts"
+
+const User = z.object({
+  name: z.string(),
+  age: z.number().int(),
+})
+const MaybeUser = maybe(User)
+
+function toolResponse(payload: unknown): unknown {
+  return {
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: {
+                name: EXTRACT_TOOL_NAME,
+                arguments: JSON.stringify(payload),
+              },
+            },
+          ],
+        },
+      },
+    ],
+  }
+}
+
+function contentResponse(payload: unknown): unknown {
+  return {
+    choices: [{ message: { role: "assistant", content: JSON.stringify(payload) } }],
+  }
+}
+
+function fakeClient(response: unknown): LLMClient {
+  return {
+    async chatCompletionsCreate() {
+      return response
+    },
+  }
+}
+
+describe("maybe", () => {
+  it("returns the extracted object when present", async () => {
+    const client = wrap(
+      fakeClient(
+        toolResponse({
+          result: { name: "John", age: 25 },
+          error: false,
+          message: null,
+        }),
+      ),
+    )
+    const value = await client.create({
+      model: "test-model",
+      schema: MaybeUser,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+    })
+    expect(value).toEqual({
+      result: { name: "John", age: 25 },
+      error: false,
+      message: null,
+    })
+  })
+
+  it("returns error=true and result=null when nothing matches", async () => {
+    const client = wrap(
+      fakeClient(
+        toolResponse({
+          result: null,
+          error: true,
+          message: "No person mentioned in the text",
+        }),
+      ),
+    )
+    const value = await client.create({
+      model: "test-model",
+      schema: MaybeUser,
+      messages: [{ role: "user", content: "It rained all afternoon." }],
+    })
+    expect(value.error).toBe(true)
+    expect(value.result).toBeNull()
+    expect(value.message).toMatch(/No person/)
+  })
+
+  it("works with JSON_SCHEMA mode", async () => {
+    const client = wrap(
+      fakeClient(
+        contentResponse({
+          result: { name: "John", age: 25 },
+          error: false,
+          message: null,
+        }),
+      ),
+      { mode: "JSON_SCHEMA" },
+    )
+    const value = await client.create({
+      model: "test-model",
+      schema: MaybeUser,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+    })
+    expect(value.result).toEqual({ name: "John", age: 25 })
+  })
+})


### PR DESCRIPTION
## What
Add `maybe(schema)` — a Zod wrapper with `result`, `error`, and `message`. Use it as `create({ schema: maybe(User), ... })`. Not a new mode.

## Why
Roadmap step 13. Extraction should be able to report a miss instead of throwing.

## Testing
- `pnpm typecheck`
- `pnpm test` (38 tests)

Covers present value, `error: true` + `result: null`, and JSON_SCHEMA.