### PR TITLE
feat: feed Zod refine failures back through reask

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,6 +1,6 @@
 import type { ZodIssue } from "zod"
 
-/** Short error text attached to the next LLM request. */
+/** Short error text attached to the next LLM request, including refine issues. */
 export function formatError(
   error: JsonParseError | SchemaValidationError,
 ): string {

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -33,6 +33,7 @@ export async function extract<T extends z.ZodType>(
 
     try {
       const json = coerceParsedValue(params.schema, handler.parseResponse(raw))
+      // Includes .refine() / .superRefine(); those issues go into reask text.
       const parsed = params.schema.safeParse(json)
       if (!parsed.success) {
         throw new SchemaValidationError(

--- a/tests/refine.test.ts
+++ b/tests/refine.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+import {
+  formatError,
+  SchemaValidationError,
+  wrap,
+  type LLMClient,
+  type RequestKwargs,
+} from "../src/index.ts"
+import { EXTRACT_TOOL_NAME } from "../src/modes/tools.ts"
+
+const Adult = z.object({
+  name: z.string(),
+  age: z.number().int().refine((value) => value >= 18, {
+    message: "must be 18 or older",
+  }),
+})
+
+function toolResponse(payload: unknown, id = "call_1"): unknown {
+  return {
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id,
+              type: "function",
+              function: {
+                name: EXTRACT_TOOL_NAME,
+                arguments: JSON.stringify(payload),
+              },
+            },
+          ],
+        },
+      },
+    ],
+  }
+}
+
+function sequenceClient(
+  responses: unknown[],
+  capture: RequestKwargs[] = [],
+): LLMClient {
+  let index = 0
+  return {
+    async chatCompletionsCreate(kwargs) {
+      capture.push(kwargs)
+      return responses[index++]
+    },
+  }
+}
+
+describe("refine reask", () => {
+  it("puts the refine message into the next tool error", async () => {
+    const capture: RequestKwargs[] = []
+    const client = wrap(
+      sequenceClient(
+        [
+          toolResponse({ name: "John", age: 10 }, "call_1"),
+          toolResponse({ name: "John", age: 18 }, "call_2"),
+        ],
+        capture,
+      ),
+    )
+
+    const user = await client.create({
+      model: "test-model",
+      schema: Adult,
+      messages: [{ role: "user", content: "John is 10" }],
+    })
+    expect(user).toEqual({ name: "John", age: 18 })
+    expect(capture).toHaveLength(2)
+    const tool = capture[1]?.messages.find((message) => message.role === "tool")
+    expect(tool?.content).toMatch(/must be 18 or older/)
+    expect(tool?.content).toMatch(/age/)
+  })
+
+  it("includes superRefine issues at the given path", async () => {
+    const Pair = z
+      .object({
+        min: z.number(),
+        max: z.number(),
+      })
+      .superRefine((value, ctx) => {
+        if (value.max < value.min) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["max"],
+            message: "max must be >= min",
+          })
+        }
+      })
+
+    const capture: RequestKwargs[] = []
+    const client = wrap(
+      sequenceClient(
+        [
+          toolResponse({ min: 10, max: 3 }, "call_1"),
+          toolResponse({ min: 3, max: 10 }, "call_2"),
+        ],
+        capture,
+      ),
+    )
+
+    const pair = await client.create({
+      model: "test-model",
+      schema: Pair,
+      messages: [{ role: "user", content: "min 10 max 3" }],
+    })
+    expect(pair).toEqual({ min: 3, max: 10 })
+    expect(capture[1]?.messages.at(-1)?.content).toMatch(/max must be >= min/)
+  })
+
+  it("formatError prints custom issue path and message", () => {
+    const parsed = Adult.safeParse({ name: "John", age: 10 })
+    expect(parsed.success).toBe(false)
+    if (parsed.success) return
+    const text = formatError(
+      new SchemaValidationError("invalid", parsed.error.issues),
+    )
+    expect(text).toMatch(/age: must be 18 or older/)
+  })
+})


### PR DESCRIPTION
## What
Guarantee that `.refine()` / `.superRefine()` failures go through the same reask loop as type errors. The custom message is included in `formatError` and the next LLM call.

## Why
Roadmap step 14. Client-side rules (age >= 18, min/max, …) are not in JSON Schema; they only work if reask sees them.

## Testing
- `pnpm typecheck`
- `pnpm test` (41 tests)

JSON Schema still strips ZodEffects (the model is not expected to encode refine).