### PR TITLE
feat: add request, parse-error, and success hooks

### DIFF
--- a/src/extract.ts
+++ b/src/extract.ts
@@ -6,7 +6,7 @@ import {
 } from "./errors.ts"
 import { handlerFor } from "./modes/registry.ts"
 import { coerceParsedValue } from "./schema.ts"
-import type { CreateParams, LLMClient, Mode } from "./types.ts"
+import type { CreateParams, Hooks, LLMClient, Mode, WrapOptions } from "./types.ts"
 
 const DEFAULT_MAX_RETRIES = 3
 const DEFAULT_MODE: Mode = "TOOLS"
@@ -14,10 +14,11 @@ const DEFAULT_MODE: Mode = "TOOLS"
 export async function extract<T extends z.ZodType>(
   client: LLMClient,
   params: CreateParams<T>,
-  defaults?: { mode?: Mode; maxRetries?: number },
+  defaults?: WrapOptions,
 ): Promise<z.infer<T>> {
   const mode = params.mode ?? defaults?.mode ?? DEFAULT_MODE
   const maxRetries = params.maxRetries ?? defaults?.maxRetries ?? DEFAULT_MAX_RETRIES
+  const hooks: Hooks = { ...defaults?.hooks, ...params.hooks }
   const attemptsAllowed = maxRetries + 1
   const handler = handlerFor(mode)
   let kwargs = handler.prepareRequest(params.schema, {
@@ -29,6 +30,7 @@ export async function extract<T extends z.ZodType>(
 
   while (attempts < attemptsAllowed) {
     attempts += 1
+    hooks.onRequest?.(kwargs)
     const raw = await client.chatCompletionsCreate(kwargs)
 
     try {
@@ -41,12 +43,14 @@ export async function extract<T extends z.ZodType>(
           parsed.error.issues,
         )
       }
+      hooks.onSuccess?.(parsed.data)
       return parsed.data
     } catch (err) {
       if (!(err instanceof JsonParseError || err instanceof SchemaValidationError)) {
         throw err
       }
       lastError = err
+      hooks.onParseError?.(err)
       if (attempts >= attemptsAllowed) {
         break
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import type { LLMClient, RubricClient, WrapOptions } from "./types.ts"
 
 export type {
   CreateParams,
+  Hooks,
   LLMClient,
   Message,
   Mode,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { z } from "zod"
+import type { JsonParseError, SchemaValidationError } from "./errors.ts"
 
 /** Request encoding used to send the schema and read JSON back. */
 export type Mode = "TOOLS" | "JSON_SCHEMA" | "MD_JSON"
@@ -33,11 +34,18 @@ export type Message = {
   tool_calls?: ToolCall[]
 }
 
+export type Hooks = {
+  onRequest?: (kwargs: RequestKwargs) => void
+  onParseError?: (error: JsonParseError | SchemaValidationError) => void
+  onSuccess?: (value: unknown) => void
+}
+
 export type WrapOptions = {
   /** Default mode for create(). Default: "TOOLS" */
   mode?: Mode
   /** Extra attempts after the first. Default: 3 */
   maxRetries?: number
+  hooks?: Hooks
 }
 
 export type CreateParams<T extends z.ZodType> = {
@@ -46,6 +54,7 @@ export type CreateParams<T extends z.ZodType> = {
   schema: T
   maxRetries?: number
   mode?: Mode
+  hooks?: Hooks
 }
 
 export type RubricClient = {

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest"
+import { z } from "zod"
+import {
+  JsonParseError,
+  SchemaValidationError,
+  wrap,
+  type LLMClient,
+  type RequestKwargs,
+} from "../src/index.ts"
+import { EXTRACT_TOOL_NAME } from "../src/modes/tools.ts"
+
+const User = z.object({
+  name: z.string(),
+  age: z.number().int(),
+})
+
+function toolResponse(payload: unknown): unknown {
+  return {
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: {
+                name: EXTRACT_TOOL_NAME,
+                arguments: JSON.stringify(payload),
+              },
+            },
+          ],
+        },
+      },
+    ],
+  }
+}
+
+function sequenceClient(
+  responses: unknown[],
+  capture: RequestKwargs[] = [],
+): LLMClient {
+  let index = 0
+  return {
+    async chatCompletionsCreate(kwargs) {
+      capture.push(kwargs)
+      const next = responses[index]
+      index += 1
+      if (next instanceof Error) {
+        throw next
+      }
+      return next
+    },
+  }
+}
+
+describe("hooks", () => {
+  it("calls onRequest, then onSuccess", async () => {
+    const onRequest = vi.fn()
+    const onParseError = vi.fn()
+    const onSuccess = vi.fn()
+    const client = wrap(sequenceClient([toolResponse({ name: "John", age: 25 })]), {
+      hooks: { onRequest, onParseError, onSuccess },
+    })
+
+    const user = await client.create({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+    })
+
+    expect(user).toEqual({ name: "John", age: 25 })
+    expect(onRequest).toHaveBeenCalledTimes(1)
+    expect(onRequest.mock.calls[0]?.[0]).toMatchObject({ model: "test-model" })
+    expect(onParseError).not.toHaveBeenCalled()
+    expect(onSuccess).toHaveBeenCalledWith({ name: "John", age: 25 })
+  })
+
+  it("calls onParseError on validation failure, then onSuccess after reask", async () => {
+    const onRequest = vi.fn()
+    const onParseError = vi.fn()
+    const onSuccess = vi.fn()
+    const client = wrap(
+      sequenceClient([
+        toolResponse({ name: "John", age: "x" }),
+        toolResponse({ name: "John", age: 25 }),
+      ]),
+      { hooks: { onRequest, onParseError, onSuccess } },
+    )
+
+    await client.create({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+    })
+
+    expect(onRequest).toHaveBeenCalledTimes(2)
+    expect(onParseError).toHaveBeenCalledTimes(1)
+    expect(onParseError.mock.calls[0]?.[0]).toBeInstanceOf(SchemaValidationError)
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not treat SDK errors as parse errors", async () => {
+    const onRequest = vi.fn()
+    const onParseError = vi.fn()
+    const onSuccess = vi.fn()
+    const boom = new Error("network down")
+    const client = wrap(sequenceClient([boom]), {
+      hooks: { onRequest, onParseError, onSuccess },
+    })
+
+    await expect(
+      client.create({
+        model: "test-model",
+        schema: User,
+        messages: [{ role: "user", content: "John is 25 years old" }],
+      }),
+    ).rejects.toBe(boom)
+
+    expect(onRequest).toHaveBeenCalledTimes(1)
+    expect(onParseError).not.toHaveBeenCalled()
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  it("lets create() hooks override wrap() hooks", async () => {
+    const wrapSuccess = vi.fn()
+    const createSuccess = vi.fn()
+    const client = wrap(sequenceClient([toolResponse({ name: "John", age: 25 })]), {
+      hooks: { onSuccess: wrapSuccess },
+    })
+
+    await client.create({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+      hooks: { onSuccess: createSuccess },
+    })
+
+    expect(createSuccess).toHaveBeenCalledTimes(1)
+    expect(wrapSuccess).not.toHaveBeenCalled()
+  })
+
+  it("calls onParseError for missing JSON", async () => {
+    const onParseError = vi.fn()
+    const client = wrap(
+      sequenceClient([{ choices: [{ message: { content: "hello" } }] }]),
+      { hooks: { onParseError } },
+    )
+
+    await client
+      .create({
+        model: "test-model",
+        schema: User,
+        messages: [{ role: "user", content: "John is 25 years old" }],
+        maxRetries: 0,
+      })
+      .catch(() => undefined)
+
+    expect(onParseError).toHaveBeenCalledTimes(1)
+    expect(onParseError.mock.calls[0]?.[0]).toBeInstanceOf(JsonParseError)
+  })
+})


### PR DESCRIPTION
## What
Add `hooks` on `wrap()` and `create()`:

- `onRequest(kwargs)` — before each LLM call (including reask)
- `onParseError(error)` — JSON / schema failures
- `onSuccess(value)` — after a validated result

`create({ hooks })` overrides matching keys from `wrap({ hooks })`.

## Why
Roadmap step 15. Observability without changing extract semantics.

## Testing
- `pnpm typecheck`
- `pnpm test` (46 tests)

SDK/network errors are not passed to `onParseError`.