### PR TITLE
feat: add Anthropic TOOLS mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const user = await client.create({
 
 ## Status
 
-v0: `wrap()` accepts a fake `LLMClient` or an OpenAI `chat.completions` client. Modes: `TOOLS`, `JSON_SCHEMA`, `MD_JSON`. Failed parses reask until `maxRetries` is exhausted.
+`wrap()` accepts a fake `LLMClient`, OpenAI `chat.completions`, or Anthropic `messages`. Modes: `TOOLS`, `JSON_SCHEMA`, `MD_JSON`, `ANTHROPIC_TOOLS`. Failed parses reask until `maxRetries` is exhausted.
 
 ```bash
 pnpm install

--- a/src/adapters/anthropic.ts
+++ b/src/adapters/anthropic.ts
@@ -1,0 +1,29 @@
+import type { LLMClient, RequestKwargs } from "../types.ts"
+
+/** Duck-typed Anthropic messages client. No hard dependency on the SDK. */
+export type AnthropicMessagesClient = {
+  messages: {
+    create: (body: unknown) => Promise<unknown>
+  }
+}
+
+export function isAnthropicMessagesClient(
+  client: unknown,
+): client is AnthropicMessagesClient {
+  if (client === null || typeof client !== "object") {
+    return false
+  }
+  const messages = (client as { messages?: unknown }).messages
+  if (messages === null || typeof messages !== "object") {
+    return false
+  }
+  return typeof (messages as { create?: unknown }).create === "function"
+}
+
+export function fromAnthropic(client: AnthropicMessagesClient): LLMClient {
+  return {
+    chatCompletionsCreate(kwargs: RequestKwargs) {
+      return client.messages.create(kwargs)
+    },
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
 import {
+  fromAnthropic,
+  isAnthropicMessagesClient,
+  type AnthropicMessagesClient,
+} from "./adapters/anthropic.ts"
+import {
   fromOpenAI,
   isLLMClient,
   isOpenAIChatClient,
@@ -8,6 +13,7 @@ import { extract } from "./extract.ts"
 import type { LLMClient, RubricClient, WrapOptions } from "./types.ts"
 
 export type {
+  ContentBlock,
   CreateParams,
   Hooks,
   LLMClient,
@@ -29,29 +35,36 @@ export {
 export { coerceParsedValue, jsonSchemaFromZod, llmJsonSchemaFromZod } from "./schema.ts"
 export type { JsonSchema } from "./schema.ts"
 export type { OpenAIChatClient } from "./adapters/openai.ts"
+export type { AnthropicMessagesClient } from "./adapters/anthropic.ts"
 export { maybe } from "./maybe.ts"
 
 /**
  * Wrap an LLM client with schema-validated create().
- * Accepts either a fake `LLMClient` or an OpenAI-shaped `chat.completions` client.
+ * Accepts a fake `LLMClient`, OpenAI `chat.completions`, or Anthropic `messages`.
  * The original client is not mutated.
  */
 export function wrap(
-  client: LLMClient | OpenAIChatClient,
+  client: LLMClient | OpenAIChatClient | AnthropicMessagesClient,
   options?: WrapOptions,
 ): RubricClient {
   let llm: LLMClient
+  let defaults = options
   if (isLLMClient(client)) {
     llm = client
   } else if (isOpenAIChatClient(client)) {
     llm = fromOpenAI(client)
+  } else if (isAnthropicMessagesClient(client)) {
+    llm = fromAnthropic(client)
+    defaults = { mode: "ANTHROPIC_TOOLS", ...options }
   } else {
-    throw new Error("wrap() expects an LLMClient or an OpenAI chat.completions client")
+    throw new Error(
+      "wrap() expects an LLMClient, OpenAI chat.completions client, or Anthropic messages client",
+    )
   }
 
   return {
     create(params) {
-      return extract(llm, params, options)
+      return extract(llm, params, defaults)
     },
   }
 }

--- a/src/modes/anthropic-tools.ts
+++ b/src/modes/anthropic-tools.ts
@@ -1,0 +1,142 @@
+import type { ZodTypeAny } from "zod"
+import {
+  formatError,
+  JsonParseError,
+  type SchemaValidationError,
+} from "../errors.ts"
+import { llmJsonSchemaFromZod } from "../schema.ts"
+import type { ContentBlock, Message, RequestKwargs } from "../types.ts"
+import { asRecord, EXTRACT_NAME } from "./helpers.ts"
+import type { ModeHandler } from "./types.ts"
+
+const DEFAULT_MAX_TOKENS = 1024
+
+function contentBlocks(raw: unknown): Record<string, unknown>[] {
+  const root = asRecord(raw)
+  const content = root?.["content"]
+  if (!Array.isArray(content)) {
+    return []
+  }
+  return content.flatMap((block) => {
+    const record = asRecord(block)
+    return record ? [record] : []
+  })
+}
+
+function toolUseBlock(
+  raw: unknown,
+): { id: string; name: string; input: unknown } | undefined {
+  for (const block of contentBlocks(raw)) {
+    if (block["type"] !== "tool_use") {
+      continue
+    }
+    const id = block["id"]
+    const name = block["name"]
+    if (typeof id !== "string" || typeof name !== "string") {
+      continue
+    }
+    return { id, name, input: block["input"] }
+  }
+  return undefined
+}
+
+export const anthropicToolsHandler: ModeHandler = {
+  prepareRequest(schema: ZodTypeAny, kwargs: RequestKwargs): RequestKwargs {
+    const systemParts: string[] = []
+    const messages: Message[] = []
+    for (const message of kwargs.messages) {
+      if (message.role === "system" && typeof message.content === "string") {
+        systemParts.push(message.content)
+        continue
+      }
+      messages.push(message)
+    }
+
+    const prepared: RequestKwargs = {
+      ...kwargs,
+      messages,
+      max_tokens: kwargs.max_tokens ?? DEFAULT_MAX_TOKENS,
+      tools: [
+        {
+          name: EXTRACT_NAME,
+          description: "Return data that matches the schema.",
+          input_schema: llmJsonSchemaFromZod(schema),
+        },
+      ],
+      tool_choice: {
+        type: "tool",
+        name: EXTRACT_NAME,
+        disable_parallel_tool_use: true,
+      },
+    }
+    if (systemParts.length > 0) {
+      prepared.system = systemParts.join("\n\n")
+    }
+    return prepared
+  },
+
+  parseResponse(raw: unknown): unknown {
+    const toolUse = toolUseBlock(raw)
+    if (!toolUse) {
+      throw new JsonParseError("Response has no tool_use block", raw)
+    }
+    const { input } = toolUse
+    if (typeof input === "string") {
+      try {
+        return JSON.parse(input) as unknown
+      } catch {
+        throw new JsonParseError("tool_use input is not valid JSON", raw)
+      }
+    }
+    if (input === undefined) {
+      throw new JsonParseError("tool_use input is missing", raw)
+    }
+    return input
+  },
+
+  handleReask(
+    kwargs: RequestKwargs,
+    raw: unknown,
+    error: JsonParseError | SchemaValidationError,
+  ): RequestKwargs {
+    const toolUse = toolUseBlock(raw)
+    const errorText = formatError(error)
+    const assistantContent: ContentBlock[] = []
+    for (const block of contentBlocks(raw)) {
+      if (block["type"] === "tool_use" && typeof block["id"] === "string") {
+        assistantContent.push({
+          type: "tool_use",
+          id: block["id"],
+          name: typeof block["name"] === "string" ? block["name"] : EXTRACT_NAME,
+          input: block["input"],
+        })
+      } else if (block["type"] === "text" && typeof block["text"] === "string") {
+        assistantContent.push({ type: "text", text: block["text"] })
+      }
+    }
+
+    const followUp: Message = toolUse
+      ? {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: toolUse.id,
+              content: errorText,
+              is_error: true,
+            },
+          ],
+        }
+      : { role: "user", content: errorText }
+
+    const assistant: Message = {
+      role: "assistant",
+      content: assistantContent.length > 0 ? assistantContent : null,
+    }
+
+    return {
+      ...kwargs,
+      messages: [...kwargs.messages, assistant, followUp],
+    }
+  },
+}

--- a/src/modes/registry.ts
+++ b/src/modes/registry.ts
@@ -1,4 +1,5 @@
 import type { Mode } from "../types.ts"
+import { anthropicToolsHandler } from "./anthropic-tools.ts"
 import { jsonSchemaHandler } from "./json-schema.ts"
 import { mdJsonHandler } from "./md-json.ts"
 import { toolsHandler } from "./tools.ts"
@@ -12,5 +13,7 @@ export function handlerFor(mode: Mode): ModeHandler {
       return jsonSchemaHandler
     case "MD_JSON":
       return mdJsonHandler
+    case "ANTHROPIC_TOOLS":
+      return anthropicToolsHandler
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import type { z } from "zod"
 import type { JsonParseError, SchemaValidationError } from "./errors.ts"
 
 /** Request encoding used to send the schema and read JSON back. */
-export type Mode = "TOOLS" | "JSON_SCHEMA" | "MD_JSON"
+export type Mode = "TOOLS" | "JSON_SCHEMA" | "MD_JSON" | "ANTHROPIC_TOOLS"
 
 /** Minimal chat-completions surface. Tests inject a fake; a live adapter comes later. */
 export type LLMClient = {
@@ -16,6 +16,8 @@ export type RequestKwargs = {
   tools?: unknown
   tool_choice?: unknown
   response_format?: unknown
+  max_tokens?: number
+  system?: string
 }
 
 export type ToolCall = {
@@ -27,9 +29,19 @@ export type ToolCall = {
   }
 }
 
+export type ContentBlock =
+  | { type: "text"; text: string }
+  | { type: "tool_use"; id: string; name: string; input: unknown }
+  | {
+      type: "tool_result"
+      tool_use_id: string
+      content: string
+      is_error?: boolean
+    }
+
 export type Message = {
   role: "system" | "user" | "assistant" | "tool"
-  content: string | null
+  content: string | null | ContentBlock[]
   tool_call_id?: string
   tool_calls?: ToolCall[]
 }

--- a/tests/anthropic-tools.test.ts
+++ b/tests/anthropic-tools.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest"
+import { z } from "zod"
+import { wrap, type LLMClient, type RequestKwargs } from "../src/index.ts"
+
+const User = z.object({
+  name: z.string(),
+  age: z.number().int(),
+})
+
+function toolUseResponse(input: unknown, id = "toolu_1"): unknown {
+  return {
+    content: [
+      {
+        type: "tool_use",
+        id,
+        name: "extract",
+        input,
+      },
+    ],
+  }
+}
+
+function sequenceClient(
+  responses: unknown[],
+  capture: RequestKwargs[] = [],
+): LLMClient {
+  let index = 0
+  return {
+    async chatCompletionsCreate(kwargs) {
+      capture.push(kwargs)
+      const next = responses[index]
+      index += 1
+      if (next instanceof Error) {
+        throw next
+      }
+      return next
+    },
+  }
+}
+
+describe("ANTHROPIC_TOOLS", () => {
+  it("extracts a User from tool_use.input", async () => {
+    const capture: RequestKwargs[] = []
+    const client = wrap(sequenceClient([toolUseResponse({ name: "John", age: 25 })], capture), {
+      mode: "ANTHROPIC_TOOLS",
+    })
+    const user = await client.create({
+      model: "test-model",
+      schema: User,
+      messages: [
+        { role: "system", content: "Extract people." },
+        { role: "user", content: "John is 25 years old" },
+      ],
+    })
+    expect(user).toEqual({ name: "John", age: 25 })
+    expect(capture[0]?.system).toBe("Extract people.")
+    expect(capture[0]?.messages.map((message) => message.role)).toEqual(["user"])
+    expect(capture[0]?.max_tokens).toBe(1024)
+    expect(capture[0]?.tools).toEqual([
+      expect.objectContaining({
+        name: "extract",
+        input_schema: expect.objectContaining({ type: "object" }),
+      }),
+    ])
+    expect(capture[0]?.tool_choice).toEqual({
+      type: "tool",
+      name: "extract",
+      disable_parallel_tool_use: true,
+    })
+  })
+
+  it("reasks with tool_result on the user turn, not role=tool", async () => {
+    const capture: RequestKwargs[] = []
+    const client = wrap(
+      sequenceClient(
+        [
+          toolUseResponse({ name: "John", age: "x" }, "toolu_1"),
+          toolUseResponse({ name: "John", age: 25 }, "toolu_2"),
+        ],
+        capture,
+      ),
+      { mode: "ANTHROPIC_TOOLS" },
+    )
+
+    const user = await client.create({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+    })
+    expect(user).toEqual({ name: "John", age: 25 })
+
+    const second = capture[1]
+    expect(second?.messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+    ])
+    const assistant = second?.messages[1]
+    expect(assistant?.content).toEqual([
+      {
+        type: "tool_use",
+        id: "toolu_1",
+        name: "extract",
+        input: { name: "John", age: "x" },
+      },
+    ])
+    const followUp = second?.messages[2]
+    expect(followUp?.content).toMatchObject([
+      {
+        type: "tool_result",
+        tool_use_id: "toolu_1",
+        is_error: true,
+      },
+    ])
+    expect(JSON.stringify(followUp?.content)).toMatch(/failed schema validation/)
+    expect(second?.tool_choice).toEqual({
+      type: "tool",
+      name: "extract",
+      disable_parallel_tool_use: true,
+    })
+  })
+
+  it("wraps an Anthropic-shaped messages.create client", async () => {
+    const create = vi.fn(async (_body: unknown) =>
+      toolUseResponse({ name: "John", age: 25 }),
+    )
+    const anthropic = { messages: { create } }
+    const client = wrap(anthropic)
+    const user = await client.create({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+    })
+    expect(user).toEqual({ name: "John", age: 25 })
+    expect(create).toHaveBeenCalledTimes(1)
+    const body = create.mock.calls[0]?.[0] as RequestKwargs
+    expect(body.tools).toBeDefined()
+    expect(body.max_tokens).toBe(1024)
+  })
+})


### PR DESCRIPTION
## What
Add `ANTHROPIC_TOOLS`: `input_schema` + `tool_choice.type=tool`, parse `content[].tool_use.input`, reask with assistant `tool_use` and a user `tool_result` (not OpenAI `role: tool`).

`wrap({ messages: { create } })` duck-types an Anthropic client and defaults the mode to `ANTHROPIC_TOOLS`.

## Why
Roadmap step 16. Same schema, second protocol — this is where library size starts to grow.

## Testing
- `pnpm typecheck`
- `pnpm test` (49 tests)

No Anthropic SDK dependency; live API is not in CI.