### PR TITLE
feat: stream partial objects with createPartial()

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const user = await client.create({
 
 ## Status
 
-`wrap()` accepts a fake `LLMClient`, OpenAI `chat.completions`, or Anthropic `messages`. Modes: `TOOLS`, `JSON_SCHEMA`, `MD_JSON`, `ANTHROPIC_TOOLS`. Failed parses reask until `maxRetries` is exhausted.
+`wrap()` accepts a fake `LLMClient`, OpenAI `chat.completions`, or Anthropic `messages`. Modes: `TOOLS`, `JSON_SCHEMA`, `MD_JSON`, `ANTHROPIC_TOOLS`. `createPartial()` streams incomplete objects (OpenAI-shaped chunks). Failed parses reask until `maxRetries` is exhausted.
 
 ```bash
 pnpm install

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "typescript": "^5.8.3",
     "vitest": "^3.2.4",
     "zod": "^3.24.0"
+  },
+  "dependencies": {
+    "partial-json": "^0.1.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      partial-json:
+        specifier: ^0.1.7
+        version: 0.1.7
     devDependencies:
       openai:
         specifier: ^4.104.0
@@ -574,6 +578,9 @@ packages:
         optional: true
       zod:
         optional: true
+
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1161,6 +1168,8 @@ snapshots:
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding
+
+  partial-json@0.1.7: {}
 
   pathe@2.0.3: {}
 

--- a/src/adapters/openai.ts
+++ b/src/adapters/openai.ts
@@ -38,5 +38,19 @@ export function fromOpenAI(client: OpenAIChatClient): LLMClient {
     chatCompletionsCreate(kwargs: RequestKwargs) {
       return client.chat.completions.create(kwargs)
     },
+    async *chatCompletionsStream(kwargs: RequestKwargs) {
+      const result = await Promise.resolve(
+        client.chat.completions.create({ ...kwargs, stream: true }),
+      )
+      if (
+        result !== null &&
+        typeof result === "object" &&
+        Symbol.asyncIterator in result
+      ) {
+        yield* result as AsyncIterable<unknown>
+        return
+      }
+      throw new Error("OpenAI stream did not return an async iterable")
+    },
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,11 +10,13 @@ import {
   type OpenAIChatClient,
 } from "./adapters/openai.ts"
 import { extract } from "./extract.ts"
+import { extractPartial } from "./partial.ts"
 import type { LLMClient, RubricClient, WrapOptions } from "./types.ts"
 
 export type {
   ContentBlock,
   CreateParams,
+  DeepPartial,
   Hooks,
   LLMClient,
   Message,
@@ -32,7 +34,12 @@ export {
   SchemaValidationError,
 } from "./errors.ts"
 
-export { coerceParsedValue, jsonSchemaFromZod, llmJsonSchemaFromZod } from "./schema.ts"
+export {
+  coerceParsedValue,
+  deepPartialZod,
+  jsonSchemaFromZod,
+  llmJsonSchemaFromZod,
+} from "./schema.ts"
 export type { JsonSchema } from "./schema.ts"
 export type { OpenAIChatClient } from "./adapters/openai.ts"
 export type { AnthropicMessagesClient } from "./adapters/anthropic.ts"
@@ -65,6 +72,9 @@ export function wrap(
   return {
     create(params) {
       return extract(llm, params, defaults)
+    },
+    createPartial(params) {
+      return extractPartial(llm, params, defaults)
     },
   }
 }

--- a/src/modes/anthropic-tools.ts
+++ b/src/modes/anthropic-tools.ts
@@ -139,4 +139,8 @@ export const anthropicToolsHandler: ModeHandler = {
       messages: [...kwargs.messages, assistant, followUp],
     }
   },
+
+  deltaFromChunk(): string {
+    return ""
+  },
 }

--- a/src/modes/helpers.ts
+++ b/src/modes/helpers.ts
@@ -10,6 +10,26 @@ export function asRecord(value: unknown): Record<string, unknown> | undefined {
   return undefined
 }
 
+export function choiceDelta(raw: unknown): Record<string, unknown> | undefined {
+  const root = asRecord(raw)
+  const choices = root?.["choices"]
+  const choice = Array.isArray(choices) ? asRecord(choices[0]) : undefined
+  return asRecord(choice?.["delta"])
+}
+
+export function openaiContentDelta(raw: unknown): string {
+  const content = choiceDelta(raw)?.["content"]
+  return typeof content === "string" ? content : ""
+}
+
+export function openaiToolArgsDelta(raw: unknown): string {
+  const delta = choiceDelta(raw)
+  const toolCalls = delta?.["tool_calls"]
+  const call = Array.isArray(toolCalls) ? asRecord(toolCalls[0]) : undefined
+  const args = asRecord(call?.["function"])?.["arguments"]
+  return typeof args === "string" ? args : ""
+}
+
 export function choiceMessage(raw: unknown): Record<string, unknown> | undefined {
   const root = asRecord(raw)
   const choices = root?.["choices"]

--- a/src/modes/json-schema.ts
+++ b/src/modes/json-schema.ts
@@ -5,6 +5,7 @@ import type { RequestKwargs } from "../types.ts"
 import {
   choiceMessage,
   EXTRACT_NAME,
+  openaiContentDelta,
   parseJsonText,
   reaskWithUserMessage,
 } from "./helpers.ts"
@@ -39,5 +40,9 @@ export const jsonSchemaHandler: ModeHandler = {
     error: JsonParseError | SchemaValidationError,
   ): RequestKwargs {
     return reaskWithUserMessage(kwargs, raw, error)
+  },
+
+  deltaFromChunk(raw: unknown): string {
+    return openaiContentDelta(raw)
   },
 }

--- a/src/modes/md-json.ts
+++ b/src/modes/md-json.ts
@@ -2,7 +2,12 @@ import type { ZodTypeAny } from "zod"
 import { JsonParseError, type SchemaValidationError } from "../errors.ts"
 import { jsonSchemaFromZod } from "../schema.ts"
 import type { RequestKwargs } from "../types.ts"
-import { choiceMessage, parseJsonText, reaskWithUserMessage } from "./helpers.ts"
+import {
+  choiceMessage,
+  openaiContentDelta,
+  parseJsonText,
+  reaskWithUserMessage,
+} from "./helpers.ts"
 import type { ModeHandler } from "./types.ts"
 
 const FENCE = /```(?:json)?\s*([\s\S]*?)```/i
@@ -56,5 +61,9 @@ export const mdJsonHandler: ModeHandler = {
     error: JsonParseError | SchemaValidationError,
   ): RequestKwargs {
     return reaskWithUserMessage(kwargs, raw, error)
+  },
+
+  deltaFromChunk(raw: unknown): string {
+    return openaiContentDelta(raw)
   },
 }

--- a/src/modes/tools.ts
+++ b/src/modes/tools.ts
@@ -11,6 +11,7 @@ import {
   assistantMessageFromRaw,
   choiceMessage,
   EXTRACT_NAME,
+  openaiToolArgsDelta,
   parseJsonText,
   readToolCalls,
 } from "./helpers.ts"
@@ -68,5 +69,9 @@ export const toolsHandler: ModeHandler = {
       ...kwargs,
       messages: [...kwargs.messages, assistant, followUp],
     }
+  },
+
+  deltaFromChunk(raw: unknown): string {
+    return openaiToolArgsDelta(raw)
   },
 }

--- a/src/modes/types.ts
+++ b/src/modes/types.ts
@@ -11,4 +11,6 @@ export type ModeHandler = {
     raw: unknown,
     error: JsonParseError | SchemaValidationError,
   ): RequestKwargs
+  /** Text delta from a streaming chunk. Empty string if this chunk has none. */
+  deltaFromChunk(raw: unknown): string
 }

--- a/src/partial.ts
+++ b/src/partial.ts
@@ -1,0 +1,84 @@
+import { parse as parsePartialJson } from "partial-json"
+import type { z } from "zod"
+import { JsonParseError } from "./errors.ts"
+import { handlerFor } from "./modes/registry.ts"
+import { coerceParsedValue, deepPartialZod } from "./schema.ts"
+import type {
+  CreateParams,
+  DeepPartial,
+  LLMClient,
+  Mode,
+  WrapOptions,
+} from "./types.ts"
+
+const DEFAULT_MODE: Mode = "TOOLS"
+
+function jsonSlice(buffer: string): string {
+  const fence = buffer.match(/```(?:json)?\s*([\s\S]*)$/i)
+  if (fence?.[1] !== undefined) {
+    return fence[1]
+  }
+  const start = buffer.search(/[{[]/)
+  return start >= 0 ? buffer.slice(start) : buffer
+}
+
+function parseIncomplete(buffer: string): unknown {
+  const slice = jsonSlice(buffer).trim()
+  if (slice === "") {
+    return undefined
+  }
+  try {
+    return parsePartialJson(slice) as unknown
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Stream incomplete snapshots. Does not reask.
+ * TOOLS / JSON_SCHEMA / MD_JSON only (OpenAI-shaped chunks).
+ */
+export async function* extractPartial<T extends z.ZodType>(
+  client: LLMClient,
+  params: CreateParams<T>,
+  defaults?: WrapOptions,
+): AsyncGenerator<DeepPartial<z.infer<T>>> {
+  const mode = params.mode ?? defaults?.mode ?? DEFAULT_MODE
+  if (mode === "ANTHROPIC_TOOLS") {
+    throw new Error("createPartial() does not support ANTHROPIC_TOOLS yet")
+  }
+  if (!client.chatCompletionsStream) {
+    throw new Error("LLMClient does not implement chatCompletionsStream")
+  }
+
+  const handler = handlerFor(mode)
+  const kwargs = handler.prepareRequest(params.schema, {
+    model: params.model,
+    messages: params.messages,
+  })
+  const partialSchema = deepPartialZod(params.schema)
+  let buffer = ""
+  let lastSerialized = ""
+
+  for await (const chunk of client.chatCompletionsStream(kwargs)) {
+    buffer += handler.deltaFromChunk(chunk)
+    const json = coerceParsedValue(params.schema, parseIncomplete(buffer))
+    if (json === undefined) {
+      continue
+    }
+    const parsed = partialSchema.safeParse(json)
+    if (!parsed.success) {
+      continue
+    }
+    const serialized = JSON.stringify(parsed.data)
+    if (serialized === lastSerialized) {
+      continue
+    }
+    lastSerialized = serialized
+    yield parsed.data as DeepPartial<z.infer<T>>
+  }
+
+  if (lastSerialized === "") {
+    throw new JsonParseError("Stream ended without parseable JSON", buffer)
+  }
+}

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -153,6 +153,26 @@ function isRootArray(schema: ZodTypeAny): boolean {
   return def(unwrap(schema).inner).typeName === "ZodArray"
 }
 
+/** All object fields optional, recursively. Used to hydrate streaming snapshots. */
+export function deepPartialZod(schema: ZodTypeAny): ZodTypeAny {
+  const { inner } = unwrap(schema)
+  const typeName = def(inner).typeName
+  if (typeName === "ZodObject") {
+    const shape: z.ZodRawShape = {}
+    for (const [key, field] of Object.entries(
+      (inner as z.ZodObject<z.ZodRawShape>).shape,
+    )) {
+      shape[key] = deepPartialZod(field).optional()
+    }
+    return z.object(shape)
+  }
+  if (typeName === "ZodArray") {
+    const element = def(inner).type as ZodTypeAny
+    return z.array(deepPartialZod(element))
+  }
+  return inner
+}
+
 function convertObject(schema: z.ZodObject<z.ZodRawShape>): JsonSchema {
   const properties: Record<string, JsonSchema> = {}
   const required: string[] = []

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export type Mode = "TOOLS" | "JSON_SCHEMA" | "MD_JSON" | "ANTHROPIC_TOOLS"
 /** Minimal chat-completions surface. Tests inject a fake; a live adapter comes later. */
 export type LLMClient = {
   chatCompletionsCreate(kwargs: RequestKwargs): Promise<unknown>
+  chatCompletionsStream?: (kwargs: RequestKwargs) => AsyncIterable<unknown>
 }
 
 /** Arguments passed to the LLM client. Modes add tools / response_format. */
@@ -18,6 +19,7 @@ export type RequestKwargs = {
   response_format?: unknown
   max_tokens?: number
   system?: string
+  stream?: boolean
 }
 
 export type ToolCall = {
@@ -69,6 +71,15 @@ export type CreateParams<T extends z.ZodType> = {
   hooks?: Hooks
 }
 
+export type DeepPartial<T> = T extends (infer U)[]
+  ? DeepPartial<U>[]
+  : T extends object
+    ? { [K in keyof T]?: DeepPartial<T[K]> }
+    : T
+
 export type RubricClient = {
   create<T extends z.ZodType>(params: CreateParams<T>): Promise<z.infer<T>>
+  createPartial<T extends z.ZodType>(
+    params: CreateParams<T>,
+  ): AsyncIterable<DeepPartial<z.infer<T>>>
 }

--- a/tests/partial.test.ts
+++ b/tests/partial.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+import { JsonParseError, wrap, type LLMClient } from "../src/index.ts"
+
+const User = z.object({
+  name: z.string(),
+  age: z.number().int(),
+})
+
+function contentDelta(text: string): unknown {
+  return { choices: [{ delta: { content: text } }] }
+}
+
+function toolArgsDelta(text: string): unknown {
+  return {
+    choices: [
+      {
+        delta: {
+          tool_calls: [{ function: { arguments: text } }],
+        },
+      },
+    ],
+  }
+}
+
+function streamClient(chunks: unknown[]): LLMClient {
+  return {
+    async chatCompletionsCreate() {
+      throw new Error("create should not be called")
+    },
+    async *chatCompletionsStream() {
+      for (const chunk of chunks) {
+        yield chunk
+      }
+    },
+  }
+}
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const items: T[] = []
+  for await (const item of iterable) {
+    items.push(item)
+  }
+  return items
+}
+
+describe("createPartial", () => {
+  it("yields growing snapshots from JSON_SCHEMA content deltas", async () => {
+    const client = wrap(
+      streamClient([
+        contentDelta('{"name": "Jo'),
+        contentDelta('hn", "age": 25}'),
+      ]),
+      { mode: "JSON_SCHEMA" },
+    )
+
+    const snapshots = await collect(
+      client.createPartial({
+        model: "test-model",
+        schema: User,
+        messages: [{ role: "user", content: "John is 25 years old" }],
+      }),
+    )
+
+    expect(snapshots[0]).toMatchObject({ name: "Jo" })
+    expect(snapshots.at(-1)).toEqual({ name: "John", age: 25 })
+  })
+
+  it("yields growing snapshots from TOOLS argument deltas", async () => {
+    const client = wrap(
+      streamClient([
+        toolArgsDelta('{"name":"John"'),
+        toolArgsDelta(',"age":25}'),
+      ]),
+    )
+
+    const snapshots = await collect(
+      client.createPartial({
+        model: "test-model",
+        schema: User,
+        messages: [{ role: "user", content: "John is 25 years old" }],
+      }),
+    )
+
+    expect(snapshots.some((snap) => snap.name === "John" && snap.age === undefined)).toBe(
+      true,
+    )
+    expect(snapshots.at(-1)).toEqual({ name: "John", age: 25 })
+  })
+
+  it("throws when the client cannot stream", async () => {
+    const client = wrap({
+      async chatCompletionsCreate() {
+        return {}
+      },
+    })
+    const iterable = client.createPartial({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+    })
+    await expect(collect(iterable)).rejects.toThrow(/chatCompletionsStream/)
+  })
+
+  it("throws for ANTHROPIC_TOOLS", async () => {
+    const client = wrap(streamClient([contentDelta("{}")]), {
+      mode: "ANTHROPIC_TOOLS",
+    })
+    const iterable = client.createPartial({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+    })
+    await expect(collect(iterable)).rejects.toThrow(/ANTHROPIC_TOOLS/)
+  })
+
+  it("throws JsonParseError when the stream never becomes JSON", async () => {
+    const client = wrap(streamClient([contentDelta("hello")]), {
+      mode: "JSON_SCHEMA",
+    })
+    const iterable = client.createPartial({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+    })
+    await expect(collect(iterable)).rejects.toBeInstanceOf(JsonParseError)
+  })
+})


### PR DESCRIPTION
## What
Add `createPartial()`: concatenate stream deltas, parse incomplete JSON with `partial-json` (not a hand-rolled parser), and yield deep-partial snapshots.

- TOOLS: `delta.tool_calls[].function.arguments`
- JSON_SCHEMA / MD_JSON: `delta.content`
- ANTHROPIC_TOOLS: not supported yet (throws)
- No reask during the stream

## Why
Roadmap step 17.

## Testing
- `pnpm typecheck`
- `pnpm test` (54 tests)