### PR TITLE
feat: stream complete list items with createIterable()

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const user = await client.create({
 
 ## Status
 
-`wrap()` accepts a fake `LLMClient`, OpenAI `chat.completions`, or Anthropic `messages`. Modes: `TOOLS`, `JSON_SCHEMA`, `MD_JSON`, `ANTHROPIC_TOOLS`. `createPartial()` streams incomplete objects (OpenAI-shaped chunks). Failed parses reask until `maxRetries` is exhausted.
+`wrap()` accepts a fake `LLMClient`, OpenAI `chat.completions`, or Anthropic `messages`. Modes: `TOOLS`, `JSON_SCHEMA`, `MD_JSON`, `ANTHROPIC_TOOLS`. `createPartial()` streams incomplete objects; `createIterable()` streams complete list items. Failed parses reask until `maxRetries` is exhausted.
 
 ```bash
 pnpm install

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   type OpenAIChatClient,
 } from "./adapters/openai.ts"
 import { extract } from "./extract.ts"
+import { extractIterable } from "./iterable.ts"
 import { extractPartial } from "./partial.ts"
 import type { LLMClient, RubricClient, WrapOptions } from "./types.ts"
 
@@ -75,6 +76,9 @@ export function wrap(
     },
     createPartial(params) {
       return extractPartial(llm, params, defaults)
+    },
+    createIterable(params) {
+      return extractIterable(llm, params, defaults)
     },
   }
 }

--- a/src/iterable.ts
+++ b/src/iterable.ts
@@ -1,0 +1,58 @@
+import { z } from "zod"
+import { JsonParseError } from "./errors.ts"
+import { handlerFor } from "./modes/registry.ts"
+import { coerceParsedValue } from "./schema.ts"
+import { parseIncomplete } from "./stream-json.ts"
+import type { CreateParams, LLMClient, Mode, WrapOptions } from "./types.ts"
+
+const DEFAULT_MODE: Mode = "TOOLS"
+
+/**
+ * Stream fully validated items from a JSON array. Incomplete trailing
+ * objects are held until they pass the item schema. Does not reask.
+ *
+ * `schema` is the **item** type; the model is asked for an array of that type.
+ */
+export async function* extractIterable<T extends z.ZodType>(
+  client: LLMClient,
+  params: CreateParams<T>,
+  defaults?: WrapOptions,
+): AsyncGenerator<z.infer<T>> {
+  const mode = params.mode ?? defaults?.mode ?? DEFAULT_MODE
+  if (mode === "ANTHROPIC_TOOLS") {
+    throw new Error("createIterable() does not support ANTHROPIC_TOOLS yet")
+  }
+  if (!client.chatCompletionsStream) {
+    throw new Error("LLMClient does not implement chatCompletionsStream")
+  }
+
+  const arraySchema = z.array(params.schema)
+  const handler = handlerFor(mode)
+  const kwargs = handler.prepareRequest(arraySchema, {
+    model: params.model,
+    messages: params.messages,
+  })
+  let buffer = ""
+  let yielded = 0
+
+  for await (const chunk of client.chatCompletionsStream(kwargs)) {
+    buffer += handler.deltaFromChunk(chunk)
+    const json = coerceParsedValue(arraySchema, parseIncomplete(buffer))
+    if (!Array.isArray(json)) {
+      continue
+    }
+    while (yielded < json.length) {
+      const item = json[yielded]
+      const parsed = params.schema.safeParse(item)
+      if (!parsed.success) {
+        break
+      }
+      yield parsed.data
+      yielded += 1
+    }
+  }
+
+  if (yielded === 0) {
+    throw new JsonParseError("Stream ended without a complete list item", buffer)
+  }
+}

--- a/src/partial.ts
+++ b/src/partial.ts
@@ -1,8 +1,8 @@
-import { parse as parsePartialJson } from "partial-json"
 import type { z } from "zod"
 import { JsonParseError } from "./errors.ts"
 import { handlerFor } from "./modes/registry.ts"
 import { coerceParsedValue, deepPartialZod } from "./schema.ts"
+import { parseIncomplete } from "./stream-json.ts"
 import type {
   CreateParams,
   DeepPartial,
@@ -12,27 +12,6 @@ import type {
 } from "./types.ts"
 
 const DEFAULT_MODE: Mode = "TOOLS"
-
-function jsonSlice(buffer: string): string {
-  const fence = buffer.match(/```(?:json)?\s*([\s\S]*)$/i)
-  if (fence?.[1] !== undefined) {
-    return fence[1]
-  }
-  const start = buffer.search(/[{[]/)
-  return start >= 0 ? buffer.slice(start) : buffer
-}
-
-function parseIncomplete(buffer: string): unknown {
-  const slice = jsonSlice(buffer).trim()
-  if (slice === "") {
-    return undefined
-  }
-  try {
-    return parsePartialJson(slice) as unknown
-  } catch {
-    return undefined
-  }
-}
 
 /**
  * Stream incomplete snapshots. Does not reask.

--- a/src/stream-json.ts
+++ b/src/stream-json.ts
@@ -1,0 +1,22 @@
+import { parse as parsePartialJson } from "partial-json"
+
+export function jsonSlice(buffer: string): string {
+  const fence = buffer.match(/```(?:json)?\s*([\s\S]*)$/i)
+  if (fence?.[1] !== undefined) {
+    return fence[1]
+  }
+  const start = buffer.search(/[{[]/)
+  return start >= 0 ? buffer.slice(start) : buffer
+}
+
+export function parseIncomplete(buffer: string): unknown {
+  const slice = jsonSlice(buffer).trim()
+  if (slice === "") {
+    return undefined
+  }
+  try {
+    return parsePartialJson(slice) as unknown
+  } catch {
+    return undefined
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,4 +82,8 @@ export type RubricClient = {
   createPartial<T extends z.ZodType>(
     params: CreateParams<T>,
   ): AsyncIterable<DeepPartial<z.infer<T>>>
+  /** Stream complete items. `schema` is the item type, not an array. */
+  createIterable<T extends z.ZodType>(
+    params: CreateParams<T>,
+  ): AsyncIterable<z.infer<T>>
 }

--- a/tests/iterable.test.ts
+++ b/tests/iterable.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+import { JsonParseError, wrap, type LLMClient } from "../src/index.ts"
+
+const User = z.object({
+  name: z.string(),
+  age: z.number().int(),
+})
+
+function contentDelta(text: string): unknown {
+  return { choices: [{ delta: { content: text } }] }
+}
+
+function toolArgsDelta(text: string): unknown {
+  return {
+    choices: [
+      {
+        delta: {
+          tool_calls: [{ function: { arguments: text } }],
+        },
+      },
+    ],
+  }
+}
+
+function streamClient(chunks: unknown[]): LLMClient {
+  return {
+    async chatCompletionsCreate() {
+      throw new Error("create should not be called")
+    },
+    async *chatCompletionsStream() {
+      for (const chunk of chunks) {
+        yield chunk
+      }
+    },
+  }
+}
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const items: T[] = []
+  for await (const item of iterable) {
+    items.push(item)
+  }
+  return items
+}
+
+describe("createIterable", () => {
+  it("yields each complete User before the next one finishes", async () => {
+    const client = wrap(
+      streamClient([
+        contentDelta('[{"name":"John","age":25},'),
+        contentDelta('{"name":"Ja'),
+        contentDelta('ne","age":30}]'),
+      ]),
+      { mode: "JSON_SCHEMA" },
+    )
+
+    const seen: unknown[][] = []
+    const items: unknown[] = []
+    for await (const item of client.createIterable({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25 and Jane is 30" }],
+    })) {
+      items.push(item)
+      seen.push([...items])
+    }
+
+    expect(seen[0]).toEqual([{ name: "John", age: 25 }])
+    expect(items).toEqual([
+      { name: "John", age: 25 },
+      { name: "Jane", age: 30 },
+    ])
+  })
+
+  it("does not yield an incomplete trailing object", async () => {
+    const client = wrap(
+      streamClient([
+        contentDelta('[{"name":"John","age":25},{"name":"Jane"}]'),
+      ]),
+      { mode: "JSON_SCHEMA" },
+    )
+
+    const items = await collect(
+      client.createIterable({
+        model: "test-model",
+        schema: User,
+        messages: [{ role: "user", content: "John and Jane" }],
+      }),
+    )
+    expect(items).toEqual([{ name: "John", age: 25 }])
+  })
+
+  it("works with TOOLS argument deltas", async () => {
+    const client = wrap(
+      streamClient([
+        toolArgsDelta('{"items":[{"name":"John","age":25},{"name":"Jane","age":30}]}'),
+      ]),
+    )
+    const items = await collect(
+      client.createIterable({
+        model: "test-model",
+        schema: User,
+        messages: [{ role: "user", content: "John is 25 and Jane is 30" }],
+      }),
+    )
+    expect(items).toEqual([
+      { name: "John", age: 25 },
+      { name: "Jane", age: 30 },
+    ])
+  })
+
+  it("throws when no complete item arrives", async () => {
+    const client = wrap(streamClient([contentDelta('[{"name":"Jo')]), {
+      mode: "JSON_SCHEMA",
+    })
+    await expect(
+      collect(
+        client.createIterable({
+          model: "test-model",
+          schema: User,
+          messages: [{ role: "user", content: "John" }],
+        }),
+      ),
+    ).rejects.toBeInstanceOf(JsonParseError)
+  })
+})


### PR DESCRIPTION
## What
Add `createIterable()`. `schema` is the **item** type; the model is asked for an array. Each item is yielded only when the full item schema succeeds (unlike `createPartial()`, which yields incomplete objects).

## Why
Roadmap step 18.

## Testing
- `pnpm typecheck`
- `pnpm test` (58 tests)

OpenAI-shaped TOOLS / JSON_SCHEMA streams. ANTHROPIC_TOOLS not supported yet.