### PR TITLE
ci: run typecheck and tests on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+      - run: pnpm test

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ pnpm typecheck
 pnpm test
 ```
 
+Pull requests and pushes to `main` run the same `typecheck` and `test` commands in GitHub Actions. Live examples are not part of CI.
+
 Live extract (not in CI):
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "engines": {
     "node": ">=20"
   },
+  "packageManager": "pnpm@10.28.2",
   "license": "MIT",
   "peerDependencies": {
     "openai": ">=4.0.0",


### PR DESCRIPTION
## What
Add `.github/workflows/ci.yml`: `pnpm install --frozen-lockfile`, `pnpm typecheck`, `pnpm test` on Node 20. Runs on pull requests and pushes to `main`.

## Why
Roadmap step 20. Catch regressions without a live LLM key.

## Testing
- `pnpm typecheck`
- `pnpm test`

This PR should go green on Actions once pushed.