### PR TITLE
feat: convert union, record, and date Zod types

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ const user = await client.create({
 | **Modes** | `TOOLS` (default), `JSON_SCHEMA`, `MD_JSON`, `ANTHROPIC_TOOLS` |
 | **Clients** | Fake `LLMClient`, OpenAI `chat.completions`, Anthropic `messages` |
 | **Lists** | `z.array(...)`; root arrays are sent as `{ items: T[] }` |
+| **Zod extras** | `z.union` / `z.discriminatedUnion`, `z.record`, `z.date()` (ISO strings) |
 | **Maybe** | `maybe(User)` → `{ result, error, message }` instead of throwing on a miss |
 | **Hooks** | `onRequest` / `onParseError` / `onSuccess` |
 | **Stream** | `createPartial()` incomplete objects; `createIterable()` complete list items |

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -5,11 +5,12 @@ export type JsonSchema = {
   type?: string | string[]
   properties?: Record<string, JsonSchema>
   required?: string[]
-  additionalProperties?: boolean
+  additionalProperties?: boolean | JsonSchema
   items?: JsonSchema
-  enum?: Array<string | number | null>
+  enum?: Array<string | number | boolean | null>
   description?: string
   anyOf?: JsonSchema[]
+  format?: string
 }
 
 type ZodDef = {
@@ -20,6 +21,10 @@ type ZodDef = {
   description?: string
   values?: string[]
   checks?: Array<{ kind: string }>
+  options?: ZodTypeAny[] | Map<string, ZodTypeAny>
+  value?: string | number | boolean
+  valueType?: ZodTypeAny
+  keyType?: ZodTypeAny
 }
 
 function def(schema: ZodTypeAny): ZodDef {
@@ -29,8 +34,8 @@ function def(schema: ZodTypeAny): ZodDef {
 /**
  * Convert a Zod schema into JSON Schema.
  *
- * Supports objects (including nested), arrays, string, number, int, boolean,
- * enum, optional, and nullable. Other Zod types throw.
+ * Supports objects, arrays, unions, records, dates (ISO strings),
+ * string, number, int, boolean, enum, literal, optional, and nullable.
  */
 export function jsonSchemaFromZod(schema: ZodTypeAny): JsonSchema {
   const { inner, optional, nullable } = unwrap(schema)
@@ -109,11 +114,52 @@ function convert(schema: ZodTypeAny): JsonSchema {
       const element = def(schema).type as ZodTypeAny
       return { type: "array", items: jsonSchemaFromZod(element) }
     }
+    case "ZodLiteral":
+      return convertLiteral(def(schema).value)
+    case "ZodUnion":
+    case "ZodDiscriminatedUnion":
+      return { anyOf: unionOptions(schema).map((option) => jsonSchemaFromZod(option)) }
+    case "ZodRecord": {
+      const valueType = def(schema).valueType
+      if (!valueType) {
+        throw new Error('ZodRecord is missing valueType')
+      }
+      return {
+        type: "object",
+        additionalProperties: jsonSchemaFromZod(valueType),
+      }
+    }
+    case "ZodDate":
+      return { type: "string", format: "date-time" }
     default:
       throw new Error(
-        `Unsupported Zod type "${typeName}". Supported: object, array, string, number, int, boolean, enum, optional, nullable.`,
+        `Unsupported Zod type "${typeName}". Supported: object, array, union, record, date, string, number, int, boolean, enum, literal, optional, nullable.`,
       )
   }
+}
+
+function convertLiteral(value: string | number | boolean | undefined): JsonSchema {
+  if (typeof value === "string") {
+    return { type: "string", enum: [value] }
+  }
+  if (typeof value === "number") {
+    return { type: "number", enum: [value] }
+  }
+  if (typeof value === "boolean") {
+    return { type: "boolean", enum: [value] }
+  }
+  throw new Error("Unsupported Zod literal value")
+}
+
+function unionOptions(schema: ZodTypeAny): ZodTypeAny[] {
+  const options = def(schema).options
+  if (Array.isArray(options)) {
+    return options
+  }
+  if (options instanceof Map) {
+    return [...options.values()]
+  }
+  throw new Error("Zod union is missing options")
 }
 
 const ROOT_ARRAY_KEY = "items"
@@ -137,15 +183,79 @@ export function llmJsonSchemaFromZod(schema: ZodTypeAny): JsonSchema {
 
 /** If the schema is a root array, accept either `T[]` or `{ items: T[] }`. */
 export function coerceParsedValue(schema: ZodTypeAny, json: unknown): unknown {
-  if (!isRootArray(schema)) {
+  let value = json
+  if (isRootArray(schema)) {
+    if (
+      !Array.isArray(value) &&
+      value !== null &&
+      typeof value === "object" &&
+      ROOT_ARRAY_KEY in value
+    ) {
+      value = (value as { items: unknown }).items
+    }
+  }
+  return coerceBySchema(schema, value)
+}
+
+function coerceBySchema(schema: ZodTypeAny, json: unknown): unknown {
+  const { inner, nullable } = unwrap(schema)
+  if (json === null && nullable) {
+    return null
+  }
+  const typeName = def(inner).typeName
+
+  if (typeName === "ZodDate") {
+    if (json instanceof Date) {
+      return json
+    }
+    if (typeof json === "string" || typeof json === "number") {
+      const date = new Date(json)
+      if (!Number.isNaN(date.getTime())) {
+        return date
+      }
+    }
     return json
   }
-  if (Array.isArray(json)) {
+
+  if (typeName === "ZodObject" && json !== null && typeof json === "object" && !Array.isArray(json)) {
+    const shape = (inner as z.ZodObject<z.ZodRawShape>).shape
+    const record = json as Record<string, unknown>
+    const out: Record<string, unknown> = { ...record }
+    for (const [key, field] of Object.entries(shape)) {
+      if (key in record) {
+        out[key] = coerceBySchema(field, record[key])
+      }
+    }
+    return out
+  }
+
+  if (typeName === "ZodArray" && Array.isArray(json)) {
+    const element = def(inner).type as ZodTypeAny
+    return json.map((item) => coerceBySchema(element, item))
+  }
+
+  if (typeName === "ZodRecord" && json !== null && typeof json === "object" && !Array.isArray(json)) {
+    const valueType = def(inner).valueType
+    if (!valueType) {
+      return json
+    }
+    const out: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(json as Record<string, unknown>)) {
+      out[key] = coerceBySchema(valueType, value)
+    }
+    return out
+  }
+
+  if (typeName === "ZodUnion" || typeName === "ZodDiscriminatedUnion") {
+    for (const option of unionOptions(inner)) {
+      const coerced = coerceBySchema(option, json)
+      if (option.safeParse(coerced).success) {
+        return coerced
+      }
+    }
     return json
   }
-  if (json !== null && typeof json === "object" && ROOT_ARRAY_KEY in json) {
-    return (json as { items: unknown }).items
-  }
+
   return json
 }
 
@@ -169,6 +279,18 @@ export function deepPartialZod(schema: ZodTypeAny): ZodTypeAny {
   if (typeName === "ZodArray") {
     const element = def(inner).type as ZodTypeAny
     return z.array(deepPartialZod(element))
+  }
+  if (typeName === "ZodUnion" || typeName === "ZodDiscriminatedUnion") {
+    const options = unionOptions(inner).map((option) => deepPartialZod(option)) as [
+      ZodTypeAny,
+      ZodTypeAny,
+      ...ZodTypeAny[],
+    ]
+    return z.union(options)
+  }
+  if (typeName === "ZodRecord") {
+    const valueType = def(inner).valueType
+    return valueType ? z.record(deepPartialZod(valueType)) : inner
   }
   return inner
 }

--- a/tests/extra-types.test.ts
+++ b/tests/extra-types.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+import { wrap, type LLMClient, type RequestKwargs } from "../src/index.ts"
+import { EXTRACT_TOOL_NAME } from "../src/modes/tools.ts"
+
+function toolResponse(payload: unknown): unknown {
+  return {
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: {
+                name: EXTRACT_TOOL_NAME,
+                arguments: JSON.stringify(payload),
+              },
+            },
+          ],
+        },
+      },
+    ],
+  }
+}
+
+function contentResponse(payload: unknown): unknown {
+  return {
+    choices: [{ message: { role: "assistant", content: JSON.stringify(payload) } }],
+  }
+}
+
+function fakeClient(response: unknown, capture: RequestKwargs[] = []): LLMClient {
+  return {
+    async chatCompletionsCreate(kwargs) {
+      capture.push(kwargs)
+      return response
+    },
+  }
+}
+
+const Pet = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("dog"), bark: z.boolean() }),
+  z.object({ kind: z.literal("cat"), lives: z.number() }),
+])
+
+describe("extra Zod types", () => {
+  it("extracts a discriminated union via TOOLS", async () => {
+    const capture: RequestKwargs[] = []
+    const client = wrap(fakeClient(toolResponse({ kind: "cat", lives: 9 }), capture))
+    const pet = await client.create({
+      model: "test-model",
+      schema: Pet,
+      messages: [{ role: "user", content: "a cat with 9 lives" }],
+    })
+    expect(pet).toEqual({ kind: "cat", lives: 9 })
+    const tools = capture[0]?.tools as Array<{
+      function: { parameters: { anyOf?: unknown[] } }
+    }>
+    expect(tools[0]?.function.parameters.anyOf).toHaveLength(2)
+  })
+
+  it("extracts ISO dates as Date via JSON_SCHEMA", async () => {
+    const Event = z.object({
+      title: z.string(),
+      at: z.date(),
+    })
+    const client = wrap(
+      fakeClient(contentResponse({ title: "Standup", at: "2026-09-11T01:00:00.000Z" })),
+      { mode: "JSON_SCHEMA" },
+    )
+    const event = await client.create({
+      model: "test-model",
+      schema: Event,
+      messages: [{ role: "user", content: "Standup at 2026-09-11T01:00:00.000Z" }],
+    })
+    expect(event.title).toBe("Standup")
+    expect(event.at).toBeInstanceOf(Date)
+    expect(event.at.toISOString()).toBe("2026-09-11T01:00:00.000Z")
+  })
+
+  it("extracts a string record", async () => {
+    const Bag = z.object({
+      labels: z.record(z.string()),
+    })
+    const client = wrap(fakeClient(toolResponse({ labels: { env: "prod", team: "core" } })))
+    const bag = await client.create({
+      model: "test-model",
+      schema: Bag,
+      messages: [{ role: "user", content: "env prod, team core" }],
+    })
+    expect(bag).toEqual({ labels: { env: "prod", team: "core" } })
+  })
+})

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -145,8 +145,36 @@ describe("jsonSchemaFromZod", () => {
     })
   })
 
+  it("converts unions and discriminated unions to anyOf", () => {
+    const Pet = z.union([
+      z.object({ kind: z.literal("dog"), bark: z.boolean() }),
+      z.object({ kind: z.literal("cat"), lives: z.number() }),
+    ])
+    const schema = jsonSchemaFromZod(Pet)
+    expect(schema.anyOf).toHaveLength(2)
+    expect(schema.anyOf?.[0]).toMatchObject({
+      properties: { kind: { type: "string", enum: ["dog"] } },
+    })
+
+    const Tagged = z.discriminatedUnion("kind", [
+      z.object({ kind: z.literal("dog"), bark: z.boolean() }),
+      z.object({ kind: z.literal("cat"), lives: z.number() }),
+    ])
+    expect(jsonSchemaFromZod(Tagged).anyOf).toHaveLength(2)
+  })
+
+  it("converts records and dates", () => {
+    expect(jsonSchemaFromZod(z.record(z.number()))).toEqual({
+      type: "object",
+      additionalProperties: { type: "number" },
+    })
+    expect(jsonSchemaFromZod(z.date())).toEqual({
+      type: "string",
+      format: "date-time",
+    })
+  })
+
   it("throws on unsupported Zod types", () => {
-    expect(() => jsonSchemaFromZod(z.date())).toThrow(/Unsupported Zod type/)
     expect(() => jsonSchemaFromZod(z.map(z.string(), z.string()))).toThrow(
       /Unsupported Zod type/,
     )


### PR DESCRIPTION
## What
`jsonSchemaFromZod` now supports:

- `z.union` / `z.discriminatedUnion` → `anyOf`
- `z.record` → `additionalProperties`
- `z.date()` → `{ type: string, format: date-time }`, ISO strings coerced to `Date` before `safeParse`
- `z.literal` (needed for discriminated unions)

## Why
Roadmap step 21.

## Testing
- `pnpm typecheck`
- `pnpm test` (65 tests)

Still unsupported: `z.map`, recursive schemas, `z.transform` as an output type.