### PR TITLE
feat: stream Anthropic tool JSON with createPartial and createIterable

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ for await (const user of client.createIterable({ model, schema: User, messages }
 }
 ```
 
-OpenAI-shaped streams only. `ANTHROPIC_TOOLS` is not supported yet.
+OpenAI-shaped chunks (`delta.content` / tool `arguments`) and Anthropic `input_json_delta.partial_json`.
 
 ### Images
 

--- a/src/adapters/anthropic.ts
+++ b/src/adapters/anthropic.ts
@@ -25,5 +25,19 @@ export function fromAnthropic(client: AnthropicMessagesClient): LLMClient {
     chatCompletionsCreate(kwargs: RequestKwargs) {
       return client.messages.create(kwargs)
     },
+    async *chatCompletionsStream(kwargs: RequestKwargs) {
+      const result = await Promise.resolve(
+        client.messages.create({ ...kwargs, stream: true }),
+      )
+      if (
+        result !== null &&
+        typeof result === "object" &&
+        Symbol.asyncIterator in result
+      ) {
+        yield* result as AsyncIterable<unknown>
+        return
+      }
+      throw new Error("Anthropic stream did not return an async iterable")
+    },
   }
 }

--- a/src/iterable.ts
+++ b/src/iterable.ts
@@ -19,9 +19,6 @@ export async function* extractIterable<T extends z.ZodType>(
   defaults?: WrapOptions,
 ): AsyncGenerator<z.infer<T>> {
   const mode = params.mode ?? defaults?.mode ?? DEFAULT_MODE
-  if (mode === "ANTHROPIC_TOOLS") {
-    throw new Error("createIterable() does not support ANTHROPIC_TOOLS yet")
-  }
   if (!client.chatCompletionsStream) {
     throw new Error("LLMClient does not implement chatCompletionsStream")
   }

--- a/src/modes/anthropic-tools.ts
+++ b/src/modes/anthropic-tools.ts
@@ -140,7 +140,13 @@ export const anthropicToolsHandler: ModeHandler = {
     }
   },
 
-  deltaFromChunk(): string {
+  deltaFromChunk(raw: unknown): string {
+    const root = asRecord(raw)
+    const delta = asRecord(root?.["delta"])
+    const partial = delta?.["partial_json"]
+    if (typeof partial === "string") {
+      return partial
+    }
     return ""
   },
 }

--- a/src/partial.ts
+++ b/src/partial.ts
@@ -15,7 +15,6 @@ const DEFAULT_MODE: Mode = "TOOLS"
 
 /**
  * Stream incomplete snapshots. Does not reask.
- * TOOLS / JSON_SCHEMA / MD_JSON only (OpenAI-shaped chunks).
  */
 export async function* extractPartial<T extends z.ZodType>(
   client: LLMClient,
@@ -23,9 +22,6 @@ export async function* extractPartial<T extends z.ZodType>(
   defaults?: WrapOptions,
 ): AsyncGenerator<DeepPartial<z.infer<T>>> {
   const mode = params.mode ?? defaults?.mode ?? DEFAULT_MODE
-  if (mode === "ANTHROPIC_TOOLS") {
-    throw new Error("createPartial() does not support ANTHROPIC_TOOLS yet")
-  }
   if (!client.chatCompletionsStream) {
     throw new Error("LLMClient does not implement chatCompletionsStream")
   }

--- a/tests/anthropic-tools.test.ts
+++ b/tests/anthropic-tools.test.ts
@@ -137,4 +137,31 @@ describe("ANTHROPIC_TOOLS", () => {
     expect(body.tools).toBeDefined()
     expect(body.max_tokens).toBe(1024)
   })
+
+  it("streams from messages.create when stream is true", async () => {
+    async function* events() {
+      yield {
+        type: "content_block_delta",
+        delta: { type: "input_json_delta", partial_json: '{"name":"John","age":25}' },
+      }
+    }
+    const create = vi.fn(async (body: unknown) => {
+      const stream = (body as { stream?: boolean }).stream
+      if (stream) {
+        return events()
+      }
+      return toolUseResponse({ name: "John", age: 25 })
+    })
+    const client = wrap({ messages: { create } })
+    const snapshots: unknown[] = []
+    for await (const snap of client.createPartial({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+    })) {
+      snapshots.push(snap)
+    }
+    expect(snapshots.at(-1)).toEqual({ name: "John", age: 25 })
+    expect(create.mock.calls[0]?.[0]).toMatchObject({ stream: true })
+  })
 })

--- a/tests/iterable.test.ts
+++ b/tests/iterable.test.ts
@@ -110,6 +110,40 @@ describe("createIterable", () => {
     ])
   })
 
+  it("yields complete items from Anthropic input_json_delta chunks", async () => {
+    const client = wrap(
+      streamClient([
+        {
+          type: "content_block_delta",
+          delta: {
+            type: "input_json_delta",
+            partial_json: '{"items":[{"name":"John","age":25},',
+          },
+        },
+        {
+          type: "content_block_delta",
+          delta: {
+            type: "input_json_delta",
+            partial_json: '{"name":"Jane","age":30}]}',
+          },
+        },
+      ]),
+      { mode: "ANTHROPIC_TOOLS" },
+    )
+
+    const items = await collect(
+      client.createIterable({
+        model: "test-model",
+        schema: User,
+        messages: [{ role: "user", content: "John is 25 and Jane is 30" }],
+      }),
+    )
+    expect(items).toEqual([
+      { name: "John", age: 25 },
+      { name: "Jane", age: 30 },
+    ])
+  })
+
   it("throws when no complete item arrives", async () => {
     const client = wrap(streamClient([contentDelta('[{"name":"Jo')]), {
       mode: "JSON_SCHEMA",

--- a/tests/partial.test.ts
+++ b/tests/partial.test.ts
@@ -102,16 +102,31 @@ describe("createPartial", () => {
     await expect(collect(iterable)).rejects.toThrow(/chatCompletionsStream/)
   })
 
-  it("throws for ANTHROPIC_TOOLS", async () => {
-    const client = wrap(streamClient([contentDelta("{}")]), {
-      mode: "ANTHROPIC_TOOLS",
-    })
-    const iterable = client.createPartial({
-      model: "test-model",
-      schema: User,
-      messages: [{ role: "user", content: "John is 25 years old" }],
-    })
-    await expect(collect(iterable)).rejects.toThrow(/ANTHROPIC_TOOLS/)
+  it("yields snapshots from Anthropic input_json_delta chunks", async () => {
+    const client = wrap(
+      streamClient([
+        {
+          type: "content_block_delta",
+          delta: { type: "input_json_delta", partial_json: '{"name": "Jo' },
+        },
+        {
+          type: "content_block_delta",
+          delta: { type: "input_json_delta", partial_json: 'hn", "age": 25}' },
+        },
+      ]),
+      { mode: "ANTHROPIC_TOOLS" },
+    )
+
+    const snapshots = await collect(
+      client.createPartial({
+        model: "test-model",
+        schema: User,
+        messages: [{ role: "user", content: "John is 25 years old" }],
+      }),
+    )
+
+    expect(snapshots[0]).toMatchObject({ name: "Jo" })
+    expect(snapshots.at(-1)).toEqual({ name: "John", age: 25 })
   })
 
   it("throws JsonParseError when the stream never becomes JSON", async () => {


### PR DESCRIPTION
## What
`ANTHROPIC_TOOLS` now works with `createPartial()` and `createIterable()`. Deltas come from `content_block_delta.delta.partial_json`. Duck-typed `messages.create({ stream: true })` is forwarded as an async iterable.

## Why
Roadmap step 22.

## Testing
- `pnpm typecheck`
- `pnpm test` (67 tests)