### PR TITLE
feat: emit an installable dist package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,4 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
       - run: pnpm test
+      - run: pnpm build

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ cd rubric
 pnpm install
 pnpm typecheck
 pnpm test
+pnpm build
 ```
 
 Pull requests and pushes to `main` run the same `typecheck` and `test` commands in GitHub Actions. Live examples are not part of CI.
@@ -68,7 +69,21 @@ ANTHROPIC_API_KEY=... pnpm example:extract-user-anthropic
 
 Optional: `OPENAI_MODEL` (default `gpt-5.6-luna`), `ANTHROPIC_MODEL` (default `claude-sonnet-4-6`).
 
-This repo is not published to npm yet. From another package, point at the path or import `src/index.ts`.
+This repo is not published to npm yet. Build the package, then depend on the folder:
+
+```bash
+pnpm build
+```
+
+```json
+{
+  "dependencies": {
+    "rubric": "file:../rubric"
+  }
+}
+```
+
+`pnpm build` writes `dist/` (`index.js` + `.d.ts`). You do not need `tsx` to load the library.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -3,15 +3,19 @@
   "version": "0.0.0",
   "description": "Schema-first structured extraction from LLMs",
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": [
-    "src"
+    "dist"
   ],
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src/adapters/anthropic.ts
+++ b/src/adapters/anthropic.ts
@@ -1,4 +1,4 @@
-import type { LLMClient, RequestKwargs } from "../types.ts"
+import type { LLMClient, RequestKwargs } from "../types.js"
 
 /** Duck-typed Anthropic messages client. No hard dependency on the SDK. */
 export type AnthropicMessagesClient = {

--- a/src/adapters/openai.ts
+++ b/src/adapters/openai.ts
@@ -1,4 +1,4 @@
-import type { LLMClient, RequestKwargs } from "../types.ts"
+import type { LLMClient, RequestKwargs } from "../types.js"
 
 /** Duck-typed OpenAI chat client. Avoids a hard runtime dependency on `openai`. */
 export type OpenAIChatClient = {

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -3,10 +3,10 @@ import {
   JsonParseError,
   RetryExhaustedError,
   SchemaValidationError,
-} from "./errors.ts"
-import { handlerFor } from "./modes/registry.ts"
-import { coerceParsedValue } from "./schema.ts"
-import type { CreateParams, Hooks, LLMClient, Mode, WrapOptions } from "./types.ts"
+} from "./errors.js"
+import { handlerFor } from "./modes/registry.js"
+import { coerceParsedValue } from "./schema.js"
+import type { CreateParams, Hooks, LLMClient, Mode, WrapOptions } from "./types.js"
 
 const DEFAULT_MAX_RETRIES = 3
 const DEFAULT_MODE: Mode = "TOOLS"

--- a/src/image.ts
+++ b/src/image.ts
@@ -1,4 +1,4 @@
-import type { ImageUrlBlock } from "./types.ts"
+import type { ImageUrlBlock } from "./types.js"
 
 /** OpenAI image part for `messages[].content`. */
 export function imageUrl(

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,17 +2,17 @@ import {
   fromAnthropic,
   isAnthropicMessagesClient,
   type AnthropicMessagesClient,
-} from "./adapters/anthropic.ts"
+} from "./adapters/anthropic.js"
 import {
   fromOpenAI,
   isLLMClient,
   isOpenAIChatClient,
   type OpenAIChatClient,
-} from "./adapters/openai.ts"
-import { extract } from "./extract.ts"
-import { extractIterable } from "./iterable.ts"
-import { extractPartial } from "./partial.ts"
-import type { LLMClient, RubricClient, WrapOptions } from "./types.ts"
+} from "./adapters/openai.js"
+import { extract } from "./extract.js"
+import { extractIterable } from "./iterable.js"
+import { extractPartial } from "./partial.js"
+import type { LLMClient, RubricClient, WrapOptions } from "./types.js"
 
 export type {
   ContentBlock,
@@ -27,26 +27,26 @@ export type {
   RubricClient,
   ToolCall,
   WrapOptions,
-} from "./types.ts"
+} from "./types.js"
 
 export {
   formatError,
   JsonParseError,
   RetryExhaustedError,
   SchemaValidationError,
-} from "./errors.ts"
+} from "./errors.js"
 
 export {
   coerceParsedValue,
   deepPartialZod,
   jsonSchemaFromZod,
   llmJsonSchemaFromZod,
-} from "./schema.ts"
-export type { JsonSchema } from "./schema.ts"
-export type { OpenAIChatClient } from "./adapters/openai.ts"
-export type { AnthropicMessagesClient } from "./adapters/anthropic.ts"
-export { maybe } from "./maybe.ts"
-export { imageUrl } from "./image.ts"
+} from "./schema.js"
+export type { JsonSchema } from "./schema.js"
+export type { OpenAIChatClient } from "./adapters/openai.js"
+export type { AnthropicMessagesClient } from "./adapters/anthropic.js"
+export { maybe } from "./maybe.js"
+export { imageUrl } from "./image.js"
 
 /**
  * Wrap an LLM client with schema-validated create().

--- a/src/iterable.ts
+++ b/src/iterable.ts
@@ -1,9 +1,9 @@
 import { z } from "zod"
-import { JsonParseError } from "./errors.ts"
-import { handlerFor } from "./modes/registry.ts"
-import { coerceParsedValue } from "./schema.ts"
-import { parseIncomplete } from "./stream-json.ts"
-import type { CreateParams, LLMClient, Mode, WrapOptions } from "./types.ts"
+import { JsonParseError } from "./errors.js"
+import { handlerFor } from "./modes/registry.js"
+import { coerceParsedValue } from "./schema.js"
+import { parseIncomplete } from "./stream-json.js"
+import type { CreateParams, LLMClient, Mode, WrapOptions } from "./types.js"
 
 const DEFAULT_MODE: Mode = "TOOLS"
 

--- a/src/modes/anthropic-tools.ts
+++ b/src/modes/anthropic-tools.ts
@@ -3,11 +3,11 @@ import {
   formatError,
   JsonParseError,
   type SchemaValidationError,
-} from "../errors.ts"
-import { llmJsonSchemaFromZod } from "../schema.ts"
-import type { ContentBlock, Message, RequestKwargs } from "../types.ts"
-import { asRecord, EXTRACT_NAME } from "./helpers.ts"
-import type { ModeHandler } from "./types.ts"
+} from "../errors.js"
+import { llmJsonSchemaFromZod } from "../schema.js"
+import type { ContentBlock, Message, RequestKwargs } from "../types.js"
+import { asRecord, EXTRACT_NAME } from "./helpers.js"
+import type { ModeHandler } from "./types.js"
 
 const DEFAULT_MAX_TOKENS = 1024
 

--- a/src/modes/helpers.ts
+++ b/src/modes/helpers.ts
@@ -1,5 +1,5 @@
-import { formatError, JsonParseError, type SchemaValidationError } from "../errors.ts"
-import type { Message, RequestKwargs, ToolCall } from "../types.ts"
+import { formatError, JsonParseError, type SchemaValidationError } from "../errors.js"
+import type { Message, RequestKwargs, ToolCall } from "../types.js"
 
 export const EXTRACT_NAME = "extract"
 

--- a/src/modes/json-schema.ts
+++ b/src/modes/json-schema.ts
@@ -1,15 +1,15 @@
 import type { ZodTypeAny } from "zod"
-import { JsonParseError, type SchemaValidationError } from "../errors.ts"
-import { llmJsonSchemaFromZod } from "../schema.ts"
-import type { RequestKwargs } from "../types.ts"
+import { JsonParseError, type SchemaValidationError } from "../errors.js"
+import { llmJsonSchemaFromZod } from "../schema.js"
+import type { RequestKwargs } from "../types.js"
 import {
   choiceMessage,
   EXTRACT_NAME,
   openaiContentDelta,
   parseJsonText,
   reaskWithUserMessage,
-} from "./helpers.ts"
-import type { ModeHandler } from "./types.ts"
+} from "./helpers.js"
+import type { ModeHandler } from "./types.js"
 
 export const jsonSchemaHandler: ModeHandler = {
   prepareRequest(schema: ZodTypeAny, kwargs: RequestKwargs): RequestKwargs {

--- a/src/modes/md-json.ts
+++ b/src/modes/md-json.ts
@@ -1,14 +1,14 @@
 import type { ZodTypeAny } from "zod"
-import { JsonParseError, type SchemaValidationError } from "../errors.ts"
-import { jsonSchemaFromZod } from "../schema.ts"
-import type { RequestKwargs } from "../types.ts"
+import { JsonParseError, type SchemaValidationError } from "../errors.js"
+import { jsonSchemaFromZod } from "../schema.js"
+import type { RequestKwargs } from "../types.js"
 import {
   choiceMessage,
   openaiContentDelta,
   parseJsonText,
   reaskWithUserMessage,
-} from "./helpers.ts"
-import type { ModeHandler } from "./types.ts"
+} from "./helpers.js"
+import type { ModeHandler } from "./types.js"
 
 const FENCE = /```(?:json)?\s*([\s\S]*?)```/i
 

--- a/src/modes/registry.ts
+++ b/src/modes/registry.ts
@@ -1,9 +1,9 @@
-import type { Mode } from "../types.ts"
-import { anthropicToolsHandler } from "./anthropic-tools.ts"
-import { jsonSchemaHandler } from "./json-schema.ts"
-import { mdJsonHandler } from "./md-json.ts"
-import { toolsHandler } from "./tools.ts"
-import type { ModeHandler } from "./types.ts"
+import type { Mode } from "../types.js"
+import { anthropicToolsHandler } from "./anthropic-tools.js"
+import { jsonSchemaHandler } from "./json-schema.js"
+import { mdJsonHandler } from "./md-json.js"
+import { toolsHandler } from "./tools.js"
+import type { ModeHandler } from "./types.js"
 
 export function handlerFor(mode: Mode): ModeHandler {
   switch (mode) {

--- a/src/modes/tools.ts
+++ b/src/modes/tools.ts
@@ -3,9 +3,9 @@ import {
   formatError,
   JsonParseError,
   type SchemaValidationError,
-} from "../errors.ts"
-import { llmJsonSchemaFromZod } from "../schema.ts"
-import type { Message, RequestKwargs } from "../types.ts"
+} from "../errors.js"
+import { llmJsonSchemaFromZod } from "../schema.js"
+import type { Message, RequestKwargs } from "../types.js"
 import {
   asRecord,
   assistantMessageFromRaw,
@@ -14,8 +14,8 @@ import {
   openaiToolArgsDelta,
   parseJsonText,
   readToolCalls,
-} from "./helpers.ts"
-import type { ModeHandler } from "./types.ts"
+} from "./helpers.js"
+import type { ModeHandler } from "./types.js"
 
 export const EXTRACT_TOOL_NAME = EXTRACT_NAME
 

--- a/src/modes/types.ts
+++ b/src/modes/types.ts
@@ -1,6 +1,6 @@
 import type { ZodTypeAny } from "zod"
-import type { JsonParseError, SchemaValidationError } from "../errors.ts"
-import type { RequestKwargs } from "../types.ts"
+import type { JsonParseError, SchemaValidationError } from "../errors.js"
+import type { RequestKwargs } from "../types.js"
 
 /** One wire format: how schema is sent, how JSON is read, how errors are attached. */
 export type ModeHandler = {

--- a/src/partial.ts
+++ b/src/partial.ts
@@ -1,15 +1,15 @@
 import type { z } from "zod"
-import { JsonParseError } from "./errors.ts"
-import { handlerFor } from "./modes/registry.ts"
-import { coerceParsedValue, deepPartialZod } from "./schema.ts"
-import { parseIncomplete } from "./stream-json.ts"
+import { JsonParseError } from "./errors.js"
+import { handlerFor } from "./modes/registry.js"
+import { coerceParsedValue, deepPartialZod } from "./schema.js"
+import { parseIncomplete } from "./stream-json.js"
 import type {
   CreateParams,
   DeepPartial,
   LLMClient,
   Mode,
   WrapOptions,
-} from "./types.ts"
+} from "./types.js"
 
 const DEFAULT_MODE: Mode = "TOOLS"
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type { z } from "zod"
-import type { JsonParseError, SchemaValidationError } from "./errors.ts"
+import type { JsonParseError, SchemaValidationError } from "./errors.js"
 
 /** Request encoding used to send the schema and read JSON back. */
 export type Mode = "TOOLS" | "JSON_SCHEMA" | "MD_JSON" | "ANTHROPIC_TOOLS"

--- a/tests/anthropic-tools.test.ts
+++ b/tests/anthropic-tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 import { z } from "zod"
-import { wrap, type LLMClient, type RequestKwargs } from "../src/index.ts"
+import { wrap, type LLMClient, type RequestKwargs } from "../src/index.js"
 
 const User = z.object({
   name: z.string(),

--- a/tests/array.test.ts
+++ b/tests/array.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { z } from "zod"
-import { wrap, type LLMClient, type RequestKwargs } from "../src/index.ts"
-import { EXTRACT_TOOL_NAME } from "../src/modes/tools.ts"
+import { wrap, type LLMClient, type RequestKwargs } from "../src/index.js"
+import { EXTRACT_TOOL_NAME } from "../src/modes/tools.js"
 
 const User = z.object({
   name: z.string(),

--- a/tests/content-modes.test.ts
+++ b/tests/content-modes.test.ts
@@ -4,7 +4,7 @@ import {
   wrap,
   type LLMClient,
   type RequestKwargs,
-} from "../src/index.ts"
+} from "../src/index.js"
 
 const User = z.object({
   name: z.string(),

--- a/tests/extra-types.test.ts
+++ b/tests/extra-types.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { z } from "zod"
-import { wrap, type LLMClient, type RequestKwargs } from "../src/index.ts"
-import { EXTRACT_TOOL_NAME } from "../src/modes/tools.ts"
+import { wrap, type LLMClient, type RequestKwargs } from "../src/index.js"
+import { EXTRACT_TOOL_NAME } from "../src/modes/tools.js"
 
 function toolResponse(payload: unknown): unknown {
   return {

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -6,8 +6,8 @@ import {
   wrap,
   type LLMClient,
   type RequestKwargs,
-} from "../src/index.ts"
-import { EXTRACT_TOOL_NAME } from "../src/modes/tools.ts"
+} from "../src/index.js"
+import { EXTRACT_TOOL_NAME } from "../src/modes/tools.js"
 
 const User = z.object({
   name: z.string(),

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -5,8 +5,8 @@ import {
   wrap,
   type LLMClient,
   type RequestKwargs,
-} from "../src/index.ts"
-import { EXTRACT_TOOL_NAME } from "../src/modes/tools.ts"
+} from "../src/index.js"
+import { EXTRACT_TOOL_NAME } from "../src/modes/tools.js"
 
 const User = z.object({
   name: z.string(),

--- a/tests/iterable.test.ts
+++ b/tests/iterable.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { z } from "zod"
-import { JsonParseError, wrap, type LLMClient } from "../src/index.ts"
+import { JsonParseError, wrap, type LLMClient } from "../src/index.js"
 
 const User = z.object({
   name: z.string(),

--- a/tests/maybe.test.ts
+++ b/tests/maybe.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { z } from "zod"
-import { maybe, wrap, type LLMClient } from "../src/index.ts"
-import { EXTRACT_TOOL_NAME } from "../src/modes/tools.ts"
+import { maybe, wrap, type LLMClient } from "../src/index.js"
+import { EXTRACT_TOOL_NAME } from "../src/modes/tools.js"
 
 const User = z.object({
   name: z.string(),

--- a/tests/openai-adapter.test.ts
+++ b/tests/openai-adapter.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 import { z } from "zod"
-import { wrap } from "../src/index.ts"
-import { EXTRACT_TOOL_NAME } from "../src/modes/tools.ts"
+import { wrap } from "../src/index.js"
+import { EXTRACT_TOOL_NAME } from "../src/modes/tools.js"
 
 const User = z.object({
   name: z.string(),

--- a/tests/partial.test.ts
+++ b/tests/partial.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { z } from "zod"
-import { JsonParseError, wrap, type LLMClient } from "../src/index.ts"
+import { JsonParseError, wrap, type LLMClient } from "../src/index.js"
 
 const User = z.object({
   name: z.string(),

--- a/tests/reask.test.ts
+++ b/tests/reask.test.ts
@@ -6,8 +6,8 @@ import {
   type LLMClient,
   type Message,
   type RequestKwargs,
-} from "../src/index.ts"
-import { EXTRACT_TOOL_NAME, toolsHandler } from "../src/modes/tools.ts"
+} from "../src/index.js"
+import { EXTRACT_TOOL_NAME, toolsHandler } from "../src/modes/tools.js"
 
 const User = z.object({
   name: z.string(),

--- a/tests/refine.test.ts
+++ b/tests/refine.test.ts
@@ -6,8 +6,8 @@ import {
   wrap,
   type LLMClient,
   type RequestKwargs,
-} from "../src/index.ts"
-import { EXTRACT_TOOL_NAME } from "../src/modes/tools.ts"
+} from "../src/index.js"
+import { EXTRACT_TOOL_NAME } from "../src/modes/tools.js"
 
 const Adult = z.object({
   name: z.string(),

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { z } from "zod"
-import { jsonSchemaFromZod, llmJsonSchemaFromZod } from "../src/schema.ts"
+import { jsonSchemaFromZod, llmJsonSchemaFromZod } from "../src/schema.js"
 
 describe("jsonSchemaFromZod", () => {
   it("converts a flat object with string and int", () => {

--- a/tests/skeleton.test.ts
+++ b/tests/skeleton.test.ts
@@ -5,7 +5,7 @@ import {
   RetryExhaustedError,
   SchemaValidationError,
   wrap,
-} from "../src/index.ts"
+} from "../src/index.js"
 
 describe("skeleton", () => {
   it("exports wrap as a function", () => {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -7,8 +7,8 @@ import {
   wrap,
   type LLMClient,
   type RequestKwargs,
-} from "../src/index.ts"
-import { EXTRACT_TOOL_NAME, toolsHandler } from "../src/modes/tools.ts"
+} from "../src/index.js"
+import { EXTRACT_TOOL_NAME, toolsHandler } from "../src/modes/tools.js"
 
 const User = z.object({
   name: z.string(),

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "verbatimModuleSyntax": true,
     "isolatedModules": true,
     "noEmit": true,
-    "allowImportingTsExtensions": true,
     "rootDir": "."
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"]


### PR DESCRIPTION
## What
- `pnpm build` emits `dist/` (JS + d.ts + source maps)
- `package.json` `exports` / `main` / `types` / `files` point at `dist`
- CI runs `pnpm build`
- Source imports use `.js` extensions (Node ESM)

## Why
Roadmap step 24. Consumers can `import { wrap } from "rubric"` after a file: dependency, without `tsx`.

## Testing
- `pnpm typecheck`
- `pnpm test` (67 tests)
- `pnpm build` then `import { wrap } from "./dist/index.js"`