### PR TITLE
fix: reject OpenAI-strict-unsafe schemas in JSON_SCHEMA

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ export {
 } from "./errors.js"
 
 export {
+  assertOpenAiStrictSchema,
   coerceParsedValue,
   deepPartialZod,
   jsonSchemaFromZod,

--- a/src/modes/json-schema.ts
+++ b/src/modes/json-schema.ts
@@ -1,6 +1,6 @@
 import type { ZodTypeAny } from "zod"
 import { JsonParseError, type SchemaValidationError } from "../errors.js"
-import { llmJsonSchemaFromZod } from "../schema.js"
+import { assertOpenAiStrictSchema, llmJsonSchemaFromZod } from "../schema.js"
 import type { RequestKwargs } from "../types.js"
 import {
   choiceMessage,
@@ -13,6 +13,8 @@ import type { ModeHandler } from "./types.js"
 
 export const jsonSchemaHandler: ModeHandler = {
   prepareRequest(schema: ZodTypeAny, kwargs: RequestKwargs): RequestKwargs {
+    const jsonSchema = llmJsonSchemaFromZod(schema)
+    assertOpenAiStrictSchema(jsonSchema)
     return {
       ...kwargs,
       response_format: {
@@ -20,7 +22,7 @@ export const jsonSchemaHandler: ModeHandler = {
         json_schema: {
           name: EXTRACT_NAME,
           strict: true,
-          schema: llmJsonSchemaFromZod(schema),
+          schema: jsonSchema,
         },
       },
     }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -322,3 +322,47 @@ function convertObject(schema: z.ZodObject<z.ZodRawShape>): JsonSchema {
   }
   return result
 }
+
+/**
+ * OpenAI `strict: true` rejects schemas Rubric still emits for TOOLS / MD_JSON.
+ * Call this from JSON_SCHEMA prepare so we fail locally instead of at the API.
+ */
+export function assertOpenAiStrictSchema(schema: JsonSchema, path = "$"): void {
+  if (schema.anyOf && schema.anyOf.length > 0) {
+    const nonNull = schema.anyOf.filter((option) => option.type !== "null")
+    const hasNull = schema.anyOf.some((option) => option.type === "null")
+    if (schema.anyOf.length === 2 && hasNull && nonNull[0]) {
+      assertOpenAiStrictSchema(nonNull[0], path)
+      return
+    }
+    throw new Error(
+      `JSON_SCHEMA strict: ${path} uses anyOf (union). OpenAI strict rejects this. Use TOOLS or MD_JSON, or a single object schema.`,
+    )
+  }
+
+  if (schema.type === "array") {
+    if (schema.items) {
+      assertOpenAiStrictSchema(schema.items, `${path}[]`)
+    }
+    return
+  }
+
+  if (schema.type === "object") {
+    if (schema.additionalProperties !== false) {
+      throw new Error(
+        `JSON_SCHEMA strict: ${path} is a record or open object (additionalProperties is not false). OpenAI strict rejects this. Use TOOLS or MD_JSON, or a fixed-key object.`,
+      )
+    }
+    const properties = schema.properties ?? {}
+    const required = new Set(schema.required ?? [])
+    const optionalKeys = Object.keys(properties).filter((key) => !required.has(key))
+    if (optionalKeys.length > 0) {
+      throw new Error(
+        `JSON_SCHEMA strict: ${path} has optional properties (${optionalKeys.join(", ")}) omitted from required. OpenAI strict requires every property in required. Use .nullable() instead of .optional(), or TOOLS / MD_JSON.`,
+      )
+    }
+    for (const [key, value] of Object.entries(properties)) {
+      assertOpenAiStrictSchema(value, `${path}.${key}`)
+    }
+  }
+}

--- a/tests/strict-schema.test.ts
+++ b/tests/strict-schema.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+import { wrap, type LLMClient } from "../src/index.js"
+import { jsonSchemaHandler } from "../src/modes/json-schema.js"
+
+const User = z.object({
+  name: z.string(),
+  age: z.number().int(),
+})
+
+function contentClient(payload: unknown): LLMClient {
+  return {
+    async chatCompletionsCreate() {
+      return {
+        choices: [
+          {
+            message: {
+              role: "assistant",
+              content: JSON.stringify(payload),
+            },
+          },
+        ],
+      }
+    },
+  }
+}
+
+describe("JSON_SCHEMA strict checks", () => {
+  it("rejects .optional() fields locally", () => {
+    const OptionalUser = z.object({
+      name: z.string(),
+      nickname: z.string().optional(),
+    })
+    expect(() =>
+      jsonSchemaHandler.prepareRequest(OptionalUser, {
+        model: "test-model",
+        messages: [],
+      }),
+    ).toThrow(/optional properties \(nickname\)/)
+  })
+
+  it("allows .nullable() fields", async () => {
+    const NullableUser = z.object({
+      name: z.string(),
+      nickname: z.string().nullable(),
+    })
+    const client = wrap(contentClient({ name: "John", nickname: null }), {
+      mode: "JSON_SCHEMA",
+    })
+    const user = await client.create({
+      model: "test-model",
+      schema: NullableUser,
+      messages: [{ role: "user", content: "John is 25 years old" }],
+    })
+    expect(user).toEqual({ name: "John", nickname: null })
+  })
+
+  it("rejects z.record locally", () => {
+    const Bag = z.object({
+      labels: z.record(z.string()),
+    })
+    expect(() =>
+      jsonSchemaHandler.prepareRequest(Bag, {
+        model: "test-model",
+        messages: [],
+      }),
+    ).toThrow(/record or open object/)
+  })
+
+  it("still allows .optional() in TOOLS", async () => {
+    const OptionalUser = z.object({
+      name: z.string(),
+      nickname: z.string().optional(),
+    })
+    const client = wrap({
+      async chatCompletionsCreate() {
+        return {
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: null,
+                tool_calls: [
+                  {
+                    id: "call_1",
+                    type: "function",
+                    function: {
+                      name: "extract",
+                      arguments: JSON.stringify({ name: "John" }),
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }
+      },
+    })
+    const user = await client.create({
+      model: "test-model",
+      schema: OptionalUser,
+      messages: [{ role: "user", content: "John" }],
+    })
+    expect(user).toEqual({ name: "John" })
+  })
+})


### PR DESCRIPTION
## What
In `JSON_SCHEMA` mode, validate the emitted schema against OpenAI `strict: true` **before** the request:

- `.optional()` fields omitted from `required` → local error (suggest `.nullable()` or TOOLS / MD_JSON)
- `z.record` / open `additionalProperties` → local error
- non-nullable `anyOf` (unions) → local error

Nullable `anyOf [type, null]` with the key in `required` still works. TOOLS and MD_JSON are unchanged.

## Why
Fixes #23. Fake clients never hit OpenAI's schema checker; live `JSON_SCHEMA` + `.optional()` failed at the API with a hard-to-read error.

## Testing
- `pnpm typecheck`
- `pnpm test` (71 tests)