### PR TITLE
feat: accumulate token usage across reask attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const user = await client.create({
 | **Lists** | `z.array(...)`; root arrays are sent as `{ items: T[] }` |
 | **Zod extras** | `z.union` / `z.discriminatedUnion`, `z.record`, `z.date()` (ISO strings) |
 | **Maybe** | `maybe(User)` → `{ result, error, message }` instead of throwing on a miss |
-| **Hooks** | `onRequest` / `onParseError` / `onSuccess` |
+| **Hooks** | `onRequest` / `onParseError` / `onSuccess` / `onUsage` (token totals across reasks) |
 | **Stream** | `createPartial()` incomplete objects; `createIterable()` complete list items |
 | **Images** | `imageUrl(url)` in `messages[].content` |
 
@@ -157,6 +157,7 @@ wrap(openai, {
     onRequest(kwargs) {},
     onParseError(error) {},
     onSuccess(value) {},
+    onUsage(usage) {},
   },
 })
 ```

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,5 @@
 import type { ZodIssue } from "zod"
+import type { TokenUsage } from "./usage.js"
 
 /** Short error text attached to the next LLM request, including refine issues. */
 export function formatError(
@@ -49,16 +50,19 @@ export class SchemaValidationError extends Error {
 export class RetryExhaustedError extends Error {
   readonly attempts: number
   readonly lastError: JsonParseError | SchemaValidationError
+  readonly usage: TokenUsage | undefined
 
   constructor(
     message: string,
     attempts: number,
     lastError: JsonParseError | SchemaValidationError,
+    usage?: TokenUsage,
   ) {
     super(message)
     this.name = "RetryExhaustedError"
     this.attempts = attempts
     this.lastError = lastError
+    this.usage = usage
     Object.setPrototypeOf(this, new.target.prototype)
   }
 }

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -7,6 +7,7 @@ import {
 import { handlerFor } from "./modes/registry.js"
 import { coerceParsedValue } from "./schema.js"
 import type { CreateParams, Hooks, LLMClient, Mode, WrapOptions } from "./types.js"
+import { addUsage, emptyUsage } from "./usage.js"
 
 const DEFAULT_MAX_RETRIES = 3
 const DEFAULT_MODE: Mode = "TOOLS"
@@ -27,11 +28,13 @@ export async function extract<T extends z.ZodType>(
   })
   let lastError: JsonParseError | SchemaValidationError | undefined
   let attempts = 0
+  let usage = emptyUsage()
 
   while (attempts < attemptsAllowed) {
     attempts += 1
     hooks.onRequest?.(kwargs)
     const raw = await client.chatCompletionsCreate(kwargs)
+    usage = addUsage(usage, raw)
 
     try {
       const json = coerceParsedValue(params.schema, handler.parseResponse(raw))
@@ -43,6 +46,7 @@ export async function extract<T extends z.ZodType>(
           parsed.error.issues,
         )
       }
+      hooks.onUsage?.(usage)
       hooks.onSuccess?.(parsed.data)
       return parsed.data
     } catch (err) {
@@ -58,9 +62,11 @@ export async function extract<T extends z.ZodType>(
     }
   }
 
+  hooks.onUsage?.(usage)
   throw new RetryExhaustedError(
     `Failed after ${attempts} attempt(s)`,
     attempts,
     lastError as JsonParseError | SchemaValidationError,
+    usage,
   )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ export {
   llmJsonSchemaFromZod,
 } from "./schema.js"
 export type { JsonSchema } from "./schema.js"
+export type { TokenUsage } from "./usage.js"
 export type { OpenAIChatClient } from "./adapters/openai.js"
 export type { AnthropicMessagesClient } from "./adapters/anthropic.js"
 export { maybe } from "./maybe.js"

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type { z } from "zod"
 import type { JsonParseError, SchemaValidationError } from "./errors.js"
+import type { TokenUsage } from "./usage.js"
 
 /** Request encoding used to send the schema and read JSON back. */
 export type Mode = "TOOLS" | "JSON_SCHEMA" | "MD_JSON" | "ANTHROPIC_TOOLS"
@@ -61,6 +62,8 @@ export type Hooks = {
   onRequest?: (kwargs: RequestKwargs) => void
   onParseError?: (error: JsonParseError | SchemaValidationError) => void
   onSuccess?: (value: unknown) => void
+  /** Totals across every attempt in this create() call, including reasks. */
+  onUsage?: (usage: TokenUsage) => void
 }
 
 export type WrapOptions = {

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,0 +1,58 @@
+export type TokenUsage = {
+  inputTokens: number
+  outputTokens: number
+  totalTokens: number
+  attempts: number
+}
+
+export function emptyUsage(): TokenUsage {
+  return { inputTokens: 0, outputTokens: 0, totalTokens: 0, attempts: 0 }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>
+  }
+  return undefined
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+/** Read OpenAI (`prompt_tokens`) or Anthropic (`input_tokens`) usage from a raw response. */
+export function readUsage(raw: unknown): { inputTokens: number; outputTokens: number } | undefined {
+  const usage = asRecord(asRecord(raw)?.["usage"])
+  if (!usage) {
+    return undefined
+  }
+  const inputTokens =
+    asNumber(usage["prompt_tokens"]) ?? asNumber(usage["input_tokens"])
+  const outputTokens =
+    asNumber(usage["completion_tokens"]) ?? asNumber(usage["output_tokens"])
+  if (inputTokens === undefined && outputTokens === undefined) {
+    return undefined
+  }
+  return {
+    inputTokens: inputTokens ?? 0,
+    outputTokens: outputTokens ?? 0,
+  }
+}
+
+export function addUsage(
+  total: TokenUsage,
+  raw: unknown,
+): TokenUsage {
+  const next = readUsage(raw)
+  if (!next) {
+    return { ...total, attempts: total.attempts + 1 }
+  }
+  const inputTokens = total.inputTokens + next.inputTokens
+  const outputTokens = total.outputTokens + next.outputTokens
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+    attempts: total.attempts + 1,
+  }
+}

--- a/tests/usage.test.ts
+++ b/tests/usage.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest"
+import { z } from "zod"
+import {
+  RetryExhaustedError,
+  wrap,
+  type LLMClient,
+  type TokenUsage,
+} from "../src/index.js"
+
+const User = z.object({
+  name: z.string(),
+  age: z.number().int(),
+})
+
+function toolResponse(
+  payload: unknown,
+  usage?: { prompt_tokens: number; completion_tokens: number },
+): unknown {
+  return {
+    usage,
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: {
+                name: "extract",
+                arguments: JSON.stringify(payload),
+              },
+            },
+          ],
+        },
+      },
+    ],
+  }
+}
+
+function sequenceClient(responses: unknown[]): LLMClient {
+  let index = 0
+  return {
+    async chatCompletionsCreate() {
+      const next = responses[index]
+      index += 1
+      return next
+    },
+  }
+}
+
+describe("token usage", () => {
+  it("reports OpenAI usage on success", async () => {
+    const onUsage = vi.fn()
+    const client = wrap(
+      sequenceClient([
+        toolResponse(
+          { name: "John", age: 25 },
+          { prompt_tokens: 10, completion_tokens: 5 },
+        ),
+      ]),
+      { hooks: { onUsage } },
+    )
+    await client.create({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25" }],
+    })
+    expect(onUsage).toHaveBeenCalledWith({
+      inputTokens: 10,
+      outputTokens: 5,
+      totalTokens: 15,
+      attempts: 1,
+    } satisfies TokenUsage)
+  })
+
+  it("sums usage across a reask", async () => {
+    const onUsage = vi.fn()
+    const client = wrap(
+      sequenceClient([
+        toolResponse(
+          { name: "John", age: "x" },
+          { prompt_tokens: 10, completion_tokens: 4 },
+        ),
+        toolResponse(
+          { name: "John", age: 25 },
+          { prompt_tokens: 20, completion_tokens: 6 },
+        ),
+      ]),
+      { hooks: { onUsage } },
+    )
+    await client.create({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25" }],
+    })
+    expect(onUsage).toHaveBeenCalledTimes(1)
+    expect(onUsage.mock.calls[0]?.[0]).toEqual({
+      inputTokens: 30,
+      outputTokens: 10,
+      totalTokens: 40,
+      attempts: 2,
+    })
+  })
+
+  it("reads Anthropic input_tokens / output_tokens", async () => {
+    const onUsage = vi.fn()
+    const client = wrap(
+      sequenceClient([
+        {
+          usage: { input_tokens: 7, output_tokens: 3 },
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_1",
+              name: "extract",
+              input: { name: "John", age: 25 },
+            },
+          ],
+        },
+      ]),
+      { mode: "ANTHROPIC_TOOLS", hooks: { onUsage } },
+    )
+    await client.create({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: "John is 25" }],
+    })
+    expect(onUsage.mock.calls[0]?.[0]).toEqual({
+      inputTokens: 7,
+      outputTokens: 3,
+      totalTokens: 10,
+      attempts: 1,
+    })
+  })
+
+  it("attaches totals on RetryExhaustedError", async () => {
+    const client = wrap(
+      sequenceClient([
+        toolResponse(
+          { name: "John" },
+          { prompt_tokens: 8, completion_tokens: 2 },
+        ),
+      ]),
+    )
+    const err = await client
+      .create({
+        model: "test-model",
+        schema: User,
+        messages: [{ role: "user", content: "John" }],
+        maxRetries: 0,
+      })
+      .catch((caught: unknown) => caught)
+    expect(err).toBeInstanceOf(RetryExhaustedError)
+    expect((err as RetryExhaustedError).usage).toEqual({
+      inputTokens: 8,
+      outputTokens: 2,
+      totalTokens: 10,
+      attempts: 1,
+    })
+  })
+})


### PR DESCRIPTION
## What
Sum token usage across every `create()` attempt (including reask):

- OpenAI: `usage.prompt_tokens` / `completion_tokens`
- Anthropic: `usage.input_tokens` / `output_tokens`

Exposed as `hooks.onUsage({ inputTokens, outputTokens, totalTokens, attempts })`. Missing usage is ignored. `RetryExhaustedError.usage` carries the same totals.

`create()` still returns `z.infer<T>` only.

## Why
Unscheduled follow-up after v0.2.0 (token totals).

## Testing
- `pnpm typecheck`
- `pnpm test` (75 tests)