### PR TITLE
feat: map image parts to Anthropic image blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ const user = await client.create({
 | **Maybe** | `maybe(User)` → `{ result, error, message }` instead of throwing on a miss |
 | **Hooks** | `onRequest` / `onParseError` / `onSuccess` / `onUsage` (token totals across reasks) |
 | **Stream** | `createPartial()` incomplete objects; `createIterable()` complete list items |
-| **Images** | `imageUrl(url)` in `messages[].content` |
+| **Images** | `imageUrl(url)` in `messages[].content` (Anthropic maps these to `image` / `source`) |
 
 Not included: a provider router, CLI, batch jobs, cache, or extra vendors.
 
@@ -65,6 +65,7 @@ cp .env.example .env   # then set OPENAI_API_KEY
 OPENAI_API_KEY=... pnpm example:extract-user
 OPENAI_API_KEY=... IMAGE_URL=https://... pnpm example:extract-image
 ANTHROPIC_API_KEY=... pnpm example:extract-user-anthropic
+ANTHROPIC_API_KEY=... IMAGE_URL=https://... pnpm example:extract-image-anthropic
 ```
 
 Optional: `OPENAI_MODEL` (default `gpt-5.6-luna`), `ANTHROPIC_MODEL` (default `claude-sonnet-4-6`).
@@ -195,6 +196,8 @@ await client.create({
   }],
 })
 ```
+
+`ANTHROPIC_TOOLS` maps `imageUrl()` to Anthropic `{ type: "image", source }`. You can also pass `anthropicImageUrl` / `anthropicImageBase64` directly.
 
 ## License
 

--- a/examples/extract-image-anthropic.ts
+++ b/examples/extract-image-anthropic.ts
@@ -1,0 +1,38 @@
+/**
+ * Live Anthropic image extract example. Not part of default CI.
+ *
+ *   ANTHROPIC_API_KEY=... IMAGE_URL=https://... pnpm example:extract-image-anthropic
+ */
+import Anthropic from "@anthropic-ai/sdk"
+import { z } from "zod"
+import { imageUrl, wrap } from "../src/index.ts"
+
+const User = z.object({
+  name: z.string(),
+  age: z.number().int(),
+})
+
+const apiKey = process.env["ANTHROPIC_API_KEY"]
+const image = process.env["IMAGE_URL"]
+if (!apiKey || !image) {
+  console.error("Set ANTHROPIC_API_KEY and IMAGE_URL to run this example.")
+  process.exit(1)
+}
+
+const client = wrap(new Anthropic({ apiKey }))
+
+const user = await client.create({
+  model: process.env["ANTHROPIC_MODEL"] ?? "claude-sonnet-4-6",
+  schema: User,
+  messages: [
+    {
+      role: "user",
+      content: [
+        { type: "text", text: "Extract the person in this image." },
+        imageUrl(image),
+      ],
+    },
+  ],
+})
+
+console.log(user)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:watch": "vitest",
     "example:extract-user": "tsx examples/extract-user.ts",
     "example:extract-image": "tsx examples/extract-image.ts",
-    "example:extract-user-anthropic": "tsx examples/extract-user-anthropic.ts"
+    "example:extract-user-anthropic": "tsx examples/extract-user-anthropic.ts",
+    "example:extract-image-anthropic": "tsx examples/extract-image-anthropic.ts"
   },
   "engines": {
     "node": ">=20"

--- a/src/image.ts
+++ b/src/image.ts
@@ -1,4 +1,4 @@
-import type { ImageUrlBlock } from "./types.js"
+import type { AnthropicImageBlock, ContentBlock, ImageUrlBlock } from "./types.js"
 
 /** OpenAI image part for `messages[].content`. */
 export function imageUrl(
@@ -9,4 +9,37 @@ export function imageUrl(
     return { type: "image_url", image_url: { url } }
   }
   return { type: "image_url", image_url: { url, detail } }
+}
+
+/** Anthropic image part from a public URL. */
+export function anthropicImageUrl(url: string): AnthropicImageBlock {
+  return { type: "image", source: { type: "url", url } }
+}
+
+/** Anthropic image part from raw base64 (no data: prefix). */
+export function anthropicImageBase64(
+  data: string,
+  mediaType: string,
+): AnthropicImageBlock {
+  return {
+    type: "image",
+    source: { type: "base64", media_type: mediaType, data },
+  }
+}
+
+const DATA_URL = /^data:([^;]+);base64,(.+)$/
+
+/** Map OpenAI `image_url` parts to Anthropic `image` parts. Other blocks unchanged. */
+export function toAnthropicContent(content: ContentBlock[]): ContentBlock[] {
+  return content.map((block) => {
+    if (block.type !== "image_url") {
+      return block
+    }
+    const url = block.image_url.url
+    const dataUrl = url.match(DATA_URL)
+    if (dataUrl?.[1] !== undefined && dataUrl[2] !== undefined) {
+      return anthropicImageBase64(dataUrl[2], dataUrl[1])
+    }
+    return anthropicImageUrl(url)
+  })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export type {
   CreateParams,
   DeepPartial,
   Hooks,
+  AnthropicImageBlock,
   ImageUrlBlock,
   LLMClient,
   Message,
@@ -48,7 +49,12 @@ export type { TokenUsage } from "./usage.js"
 export type { OpenAIChatClient } from "./adapters/openai.js"
 export type { AnthropicMessagesClient } from "./adapters/anthropic.js"
 export { maybe } from "./maybe.js"
-export { imageUrl } from "./image.js"
+export {
+  anthropicImageBase64,
+  anthropicImageUrl,
+  imageUrl,
+  toAnthropicContent,
+} from "./image.js"
 
 /**
  * Wrap an LLM client with schema-validated create().

--- a/src/modes/anthropic-tools.ts
+++ b/src/modes/anthropic-tools.ts
@@ -5,6 +5,7 @@ import {
   type SchemaValidationError,
 } from "../errors.js"
 import { llmJsonSchemaFromZod } from "../schema.js"
+import { toAnthropicContent } from "../image.js"
 import type { ContentBlock, Message, RequestKwargs } from "../types.js"
 import { asRecord, EXTRACT_NAME } from "./helpers.js"
 import type { ModeHandler } from "./types.js"
@@ -47,6 +48,13 @@ export const anthropicToolsHandler: ModeHandler = {
     for (const message of kwargs.messages) {
       if (message.role === "system" && typeof message.content === "string") {
         systemParts.push(message.content)
+        continue
+      }
+      if (Array.isArray(message.content)) {
+        messages.push({
+          ...message,
+          content: toAnthropicContent(message.content),
+        })
         continue
       }
       messages.push(message)

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,9 +40,17 @@ export type ImageUrlBlock = {
   }
 }
 
+export type AnthropicImageBlock = {
+  type: "image"
+  source:
+    | { type: "url"; url: string }
+    | { type: "base64"; media_type: string; data: string }
+}
+
 export type ContentBlock =
   | { type: "text"; text: string }
   | ImageUrlBlock
+  | AnthropicImageBlock
   | { type: "tool_use"; id: string; name: string; input: unknown }
   | {
       type: "tool_result"

--- a/tests/image.test.ts
+++ b/tests/image.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { z } from "zod"
 import {
+  anthropicImageUrl,
   imageUrl,
   wrap,
   type LLMClient,
@@ -108,6 +109,49 @@ describe("image messages", () => {
     expect(userMessage?.content).toEqual([
       { type: "text", text: "Who is this?" },
       { type: "image_url", image_url: { url: "data:image/png;base64,aaa" } },
+    ])
+  })
+
+  it("maps OpenAI image_url to Anthropic image parts", async () => {
+    const capture: RequestKwargs[] = []
+    const original = [
+      { type: "text" as const, text: "Who is this?" },
+      imageUrl("https://example.com/person.jpg"),
+      imageUrl("data:image/png;base64,aaa"),
+    ]
+    const client = wrap(
+      {
+        async chatCompletionsCreate(kwargs) {
+          capture.push(kwargs)
+          return {
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_1",
+                name: "extract",
+                input: { name: "John", age: 25 },
+              },
+            ],
+          }
+        },
+      } satisfies LLMClient,
+      { mode: "ANTHROPIC_TOOLS" },
+    )
+
+    await client.create({
+      model: "test-model",
+      schema: User,
+      messages: [{ role: "user", content: original }],
+    })
+
+    expect(original[1]).toEqual(imageUrl("https://example.com/person.jpg"))
+    expect(capture[0]?.messages[0]?.content).toEqual([
+      { type: "text", text: "Who is this?" },
+      anthropicImageUrl("https://example.com/person.jpg"),
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: "aaa" },
+      },
     ])
   })
 })


### PR DESCRIPTION
## What
`ANTHROPIC_TOOLS` now accepts vision messages:

- `imageUrl(https://...)` → `{ type: \"image\", source: { type: \"url\" } }`
- `imageUrl(data:image/...;base64,...)` → `{ type: \"image\", source: { type: \"base64\" } }`
- Helpers: `anthropicImageUrl`, `anthropicImageBase64`

User message arrays are copied; the original `image_url` parts stay unchanged.

## Why
Last unscheduled follow-up after v0.2.0.

## Testing
- `pnpm typecheck`
- `pnpm test` (76 tests)

Live: `ANTHROPIC_API_KEY=... IMAGE_URL=... pnpm example:extract-image-anthropic`